### PR TITLE
Add hardcoded DNS server

### DIFF
--- a/android/tool/src/main/java/io/netbird/client/tool/DNSWatch.java
+++ b/android/tool/src/main/java/io/netbird/client/tool/DNSWatch.java
@@ -118,6 +118,9 @@ public class DNSWatch {
     }
 
     private void extendWithFallbackDNS(List<InetAddress> dnsServers) {
+        if (dnsServers.isEmpty()) {
+            return;
+        }
         if (dnsServers.get(0).isLinkLocalAddress()) {
             try {
                 InetAddress addr = InetAddress.getByName("1.1.1.1");


### PR DESCRIPTION
Extend the host's DNS list with the hardcoded Cloudflare DNS server in case the first assigned server type is link local