### PR TITLE
Increase the target sdk version to 34

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -62,7 +62,7 @@ jobs:
       - name: build debug apk
         run: cd android && ./gradlew assembleDebug
       - name: upload non tags for debug purposes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: debug-apk
           path: android/app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.21.x"
+          go-version: "1.23.3"
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
         with:

--- a/android/app/src/main/java/io/netbird/client/MainApplication.java
+++ b/android/app/src/main/java/io/netbird/client/MainApplication.java
@@ -58,7 +58,7 @@ public class MainApplication extends Application implements ReactApplication {
     private void registerNotificationReceiver() {
         IntentFilter filter = new IntentFilter();
         filter.addAction(NetworkChangeNotifier.action);
-        registerReceiver(notificationReceiver, filter);
+        registerReceiver(notificationReceiver, filter, RECEIVER_NOT_EXPORTED);
     }
 
     @Override

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,8 +4,8 @@ buildscript {
     ext {
         buildToolsVersion = "33.0.0"
         minSdkVersion = 26
-        compileSdkVersion = 33
-        targetSdkVersion = 33
+        compileSdkVersion = 34
+        targetSdkVersion = 34
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
         ndkVersion = "23.1.7779620"

--- a/android/tool/src/main/AndroidManifest.xml
+++ b/android/tool/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SYSTEM_EXEMPTED" />
 
     <application
         android:allowBackup="false"
@@ -13,7 +15,8 @@
         <service
             android:name=".VPNService"
             android:permission="android.permission.BIND_VPN_SERVICE"
-            android:exported="false">
+            android:exported="false"
+            android:foregroundServiceType="systemExempted">
             <intent-filter>
                 <action android:name="android.net.VpnService"/>
                 <action android:name="io.netbird.client.intent.action.START_SERVICE" />


### PR DESCRIPTION
https://developer.android.com/about/versions/14/changes/fgs-types-required#permission-for-fgs-type

If apps that target Android 14 use a foreground service, they must declare a specific permission, based on the foreground service type, that Android 14 introduces. These permissions appear in the sections labeled "permission that you must declare in your manifest file" in the [intended use cases and enforcement for each foreground service type](https://developer.android.com/about/versions/14/changes/fgs-types-required#use-cases) section on this page.

- update compile SDK version to 34
- update Go version in CI