### PR TITLE
Use git tag as version name for Go lib

### DIFF
--- a/build-android-lib.sh
+++ b/build-android-lib.sh
@@ -4,9 +4,34 @@
 # If no version is provided, "development" is used as default
 set -e
 
-# Set version from the first argument or use "development" as default
-version=${1:-development}
 app_path=$(pwd)
+
+
+get_version() {
+  # If user passed a version, use it
+  if [ -n "$1" ]; then
+    echo "$1"
+    return
+  fi
+
+  # No version passed, try to detect a Git tag
+  cd netbird
+  local tag=$(git describe --tags --exact-match 2>/dev/null || true)
+  cd - > /dev/null
+
+  # Use tag if found, otherwise default to "development"
+  if [ -n "$tag" ]; then
+    echo "$tag"
+  else
+    echo "development"
+  fi
+}
+
+# Get version using the function
+version=$(get_version "$1")
+
+echo "Using version: $version"
+
 
 cd netbird
 gomobile init


### PR DESCRIPTION
This PR updates the gomobile build script to better handle versioning:

Introduces a get_version function to encapsulate logic.

- Prioritizes user-supplied version arguments (./script.sh myfeature-rc1) over Git tags.
- Falls back to Git tag on current HEAD if no version is provided.
- Defaults to **development** when no tag or argument is available.