### PR TITLE
fix: (AdvancedFragment.java) save pre-shared key correctly

### DIFF
--- a/app/src/main/java/io/netbird/client/ui/advanced/AdvancedFragment.java
+++ b/app/src/main/java/io/netbird/client/ui/advanced/AdvancedFragment.java
@@ -238,13 +238,20 @@ public class AdvancedFragment extends Fragment {
         String base64Pattern = "^[A-Za-z0-9+/=]{32,64}$";
         return key.matches(base64Pattern);
     }
-
+    
     private void setPreSharedKey(String key, Context context) {
         String configFilePath = Preferences.configFile(context);
         io.netbird.gomobile.android.Preferences preferences = new io.netbird.gomobile.android.Preferences(configFilePath);
-        preferences.setPreSharedKey(key);
+        try {
+            preferences.setPreSharedKey(key);
+            preferences.commit();
+            Toast.makeText(context, "Pre-shared key saved successfully", Toast.LENGTH_SHORT).show();
+        } catch (Exception e) {
+            Log.e(LOGTAG, "Failed to save pre-shared key", e);
+            Toast.makeText(context, "Error saving key: " + e.getMessage(), Toast.LENGTH_LONG).show();
+        }
     }
-
+    
     private boolean hasPreSharedKey(Context context) {
         String configFilePath = Preferences.configFile(context);
         io.netbird.gomobile.android.Preferences preferences = new io.netbird.gomobile.android.Preferences(configFilePath);

--- a/app/src/main/java/io/netbird/client/ui/advanced/AdvancedFragment.java
+++ b/app/src/main/java/io/netbird/client/ui/advanced/AdvancedFragment.java
@@ -271,20 +271,20 @@ public class AdvancedFragment extends Fragment {
         String base64Pattern = "^[A-Za-z0-9+/=]{32,64}$";
         return key.matches(base64Pattern);
     }
-    
+
     private void setPreSharedKey(String key, Context context) {
         String configFilePath = Preferences.configFile(context);
         io.netbird.gomobile.android.Preferences preferences = new io.netbird.gomobile.android.Preferences(configFilePath);
         try {
             preferences.setPreSharedKey(key);
             preferences.commit();
-            Toast.makeText(context, "Pre-shared key saved successfully", Toast.LENGTH_SHORT).show();
+            Toast.makeText(context, R.string.advanced_presharedkey_saved_success, Toast.LENGTH_SHORT).show();
         } catch (Exception e) {
             Log.e(LOGTAG, "Failed to save pre-shared key", e);
-            Toast.makeText(context, "Error saving key: " + e.getMessage(), Toast.LENGTH_LONG).show();
+            Toast.makeText(context, R.string.advanced_presharedkey_save_error + ": " + e.getMessage(), Toast.LENGTH_LONG).show();
         }
     }
-    
+
     private boolean hasPreSharedKey(Context context) {
         String configFilePath = Preferences.configFile(context);
         io.netbird.gomobile.android.Preferences preferences = new io.netbird.gomobile.android.Preferences(configFilePath);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,6 +71,8 @@
     <string name="advanced_details">You will only communicate with peers that use the same key.</string>
     <string name="advanced_hint">Add a pre-shared key</string>
     <string name="advanced_save">Save</string>
+    <string name="advanced_presharedkey_saved_success">Pre-shared key saved successfully</string>
+    <string name="advanced_presharedkey_save_error">Failed to save pre-shared key</string>
     <string name="advanced_tracelog">Enable trace log level.</string>
     <string name="advanced_share_logs">Share logs</string>
     <string name="advanced_rosenpass">Enable Rosenpass</string>


### PR DESCRIPTION
## Description

Add `preferences.commit()` call to save pre-shared key correctly and show user feedback via Toast messages.

## Related Issue

Closes #78 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update