### PR TITLE
Update firebase-bom and firebase-crashlytics-plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,9 +12,9 @@ lifecycleLivedataKtx = "2.9.0"
 lifecycleViewmodelKtx = "2.9.0"
 navigationFragment = "2.9.0"
 navigationUi = "2.9.0"
-firebase-bom = "33.14.0"
+firebase-bom = "34.2.0"
 google-services = "4.4.2"
-firebase-crashlytics-plugin = "3.0.3"
+firebase-crashlytics-plugin = "3.0.6"
 
 [libraries]
 browser = { module = "androidx.browser:browser", version.ref = "browser" }


### PR DESCRIPTION
Updating firebase references due to JobInfoSchedulerService from firebase sdk throwing fatal exceptions:

Fatal Exception: android.app.RemoteServiceException$ForegroundServiceDidNotStartInTimeException: Context.startForegroundService() did not then call Service.startForeground(): ServiceRecord{b207ed7 u0 io.netbird.client/com.google.android.datatransport.runtime.scheduling.jobscheduling.JobInfoSchedulerService}

firebase-bom: 33.14.0 -> 34.2.0
firebase-crashlytics-plugin: 3.0.3 -> 3.0.6