### PR TITLE
Enable force relay connection by default

### DIFF
--- a/tool/src/androidTest/java/io/netbird/client/tool/PreferencesInstrumentedTest.java
+++ b/tool/src/androidTest/java/io/netbird/client/tool/PreferencesInstrumentedTest.java
@@ -45,8 +45,8 @@ public class PreferencesInstrumentedTest {
     }
 
     @Test
-    public void shouldReturnFalseWhenConnectionForceRelayedIsNotSet() {
-        Assert.assertFalse(preferences.isConnectionForceRelayed());
+    public void shouldReturnTrueWhenConnectionForceRelayedIsNotSet() {
+        Assert.assertTrue(preferences.isConnectionForceRelayed());
     }
 
     @Test

--- a/tool/src/main/java/io/netbird/client/tool/Preferences.java
+++ b/tool/src/main/java/io/netbird/client/tool/Preferences.java
@@ -34,7 +34,7 @@ public class Preferences {
     }
 
     public boolean isConnectionForceRelayed() {
-        return sharedPref.getBoolean(keyForceRelayConnection, false);
+        return sharedPref.getBoolean(keyForceRelayConnection, true);
     }
 
     public void enableForcedRelayConnection() {


### PR DESCRIPTION
This PR changes the default behavior of the force relay connection option.
If not set, android clients from now on will be using the relay server to connect to peers.