### PR TITLE
Remove route change notification UI elements

### DIFF
--- a/app/src/main/java/io/netbird/client/ui/home/HomeFragment.java
+++ b/app/src/main/java/io/netbird/client/ui/home/HomeFragment.java
@@ -110,9 +110,6 @@ public class HomeFragment extends Fragment implements StateListener {
         });
 
         if (PlatformUtils.isAndroidTV(requireContext())) {
-            binding.btnRouteChanged.setFocusable(false);
-            binding.btnRouteChanged.setFocusableInTouchMode(false);
-            
             root.postDelayed(() -> {
                 if (buttonConnect != null && buttonConnect.isEnabled()) {
                     buttonConnect.requestFocus();

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -100,22 +100,6 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />
 
-        <ImageButton
-            android:id="@+id/btn_route_changed"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:background="@drawable/focus_highlight_button"
-            android:contentDescription="@string/main_desc_new_route_notification"
-            android:focusable="true"
-            android:focusableInTouchMode="false"
-            android:padding="8dp"
-            android:src="@drawable/ic_menu_about"
-            app:tint="@color/nb_orange"
-            app:layout_constraintStart_toEndOf="@id/text_connection_status"
-            app:layout_constraintTop_toTopOf="@id/text_connection_status"
-            app:layout_constraintBottom_toBottomOf="@id/text_connection_status" />
-
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <View

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,7 +15,6 @@
     <string name="main_status_disconnected">Disconnected</string>
     <string name="main_desc_bg_mask">background mask</string>
     <string name="main_desc_connect">connect-disconnect</string>
-    <string name="main_desc_new_route_notification">new route notification</string>
 
     <string name="fragment_firstinstall_txt">By default you will connect to NetBird\'s cloud servers. You can access the change_server menu to use another server.</string>
     <string name="fragment_firstinstall_continue">Continue</string>


### PR DESCRIPTION
This restores the intent of PR #105 which removed the route change notification feature. PR #100 accidentally reintroduced these elements due to a force push that overwrote PR #105 changes."