### PR TITLE
Allow http and https as url

### DIFF
--- a/app/src/main/java/io/netbird/client/ui/server/ChangeServerFragmentViewModel.java
+++ b/app/src/main/java/io/netbird/client/ui/server/ChangeServerFragmentViewModel.java
@@ -68,7 +68,7 @@ public class ChangeServerFragmentViewModel extends ViewModel {
     }
 
     private boolean isUrlInvalid(String url) {
-        if (!url.matches("^https://.*")) return true;
+        if (!url.matches("^https?://.*")) return true;
 
         try {
             new URL(url);


### PR DESCRIPTION
Changed regex pattern from ^https://.* to ^https?://.* to support both protocols while maintaining basic URL format validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated server URL validation to accept both HTTP and HTTPS protocols. Previously, only HTTPS connections were allowed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->