### PR TITLE
bug: race condition when checking if NetworkAvailabilityListener is null on ConnectivityManager.NetworkCallback()

### DIFF
--- a/tool/src/main/java/io/netbird/client/tool/networks/NetworkChangeDetector.java
+++ b/tool/src/main/java/io/netbird/client/tool/networks/NetworkChangeDetector.java
@@ -13,7 +13,7 @@ public class NetworkChangeDetector {
     private static final String LOGTAG = NetworkChangeDetector.class.getSimpleName();
     private final ConnectivityManager connectivityManager;
     private ConnectivityManager.NetworkCallback networkCallback;
-    private NetworkAvailabilityListener listener;
+    private volatile NetworkAvailabilityListener listener;
 
     public NetworkChangeDetector(ConnectivityManager connectivityManager) {
         this.connectivityManager = connectivityManager;
@@ -37,14 +37,16 @@ public class NetworkChangeDetector {
         networkCallback = new ConnectivityManager.NetworkCallback() {
             @Override
             public void onAvailable(@NonNull Network network) {
-                if (listener == null) return;
-                checkNetworkCapabilities(network, (networkType) -> listener.onNetworkAvailable(networkType));
+                NetworkAvailabilityListener localListener = listener;
+                if (localListener == null) return;
+                checkNetworkCapabilities(network, localListener::onNetworkAvailable);
             }
 
             @Override
             public void onLost(@NonNull Network network) {
-                if (listener == null) return;
-                checkNetworkCapabilities(network, (networkType) -> listener.onNetworkLost(networkType));
+                NetworkAvailabilityListener localListener = listener;
+                if (localListener == null) return;
+                checkNetworkCapabilities(network, localListener::onNetworkLost);
             }
 
             @Override


### PR DESCRIPTION
This PR addresses the racing condition issue where a thread may set NetworkChangeDetector's listener to null while another is trying to call its methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread safety in network change detection to prevent potential race conditions during network state updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->