### PR TITLE
Keep fragments from inflating repeatedly

### DIFF
--- a/app/src/main/java/io/netbird/client/MainActivity.java
+++ b/app/src/main/java/io/netbird/client/MainActivity.java
@@ -319,9 +319,9 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
         // Use NavigationUI which handles launchSingleTop and saveState/restoreState
         // This prevents fragment recreation and preserves state when alternating between destinations
-        NavigationUI.onNavDestinationSelected(item, navController);
+        boolean isHandled = NavigationUI.onNavDestinationSelected(item, navController);
         binding.drawerLayout.closeDrawers();
-        return false;
+        return isHandled;
     }
 
     @Override


### PR DESCRIPTION
There is a bug on NavigationDrawer where if an user taps a given option multiple times, fragments will be inflated repeatedly.

This PR changes the way the fragments are inflated so that each fragment is inflated only once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation handling to respect the navigation system's handled status, reducing unnecessary screen reloads and better preserving user state when switching destinations.
  * Ensures the navigation drawer closes correctly after selection while honoring whether the destination action was processed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->