### PR TITLE
Add lazy connection toggle

### DIFF
--- a/app/src/main/java/io/netbird/client/ui/advanced/AdvancedFragment.java
+++ b/app/src/main/java/io/netbird/client/ui/advanced/AdvancedFragment.java
@@ -65,6 +65,27 @@ public class AdvancedFragment extends Fragment {
         });
     }
 
+    private void configureEnableLazyConnectionSwitch(@NonNull ComponentSwitchBinding binding, @NonNull Preferences preferences) {
+        binding.switchTitle.setText(R.string.advanced_enable_lazy_conn);
+        binding.switchDescription.setText(R.string.advanced_enable_lazy_conn_desc);
+
+        binding.switchControl.setChecked(preferences.isLazyConnectionEnabled());
+        binding.switchControl.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            if (isChecked) {
+                preferences.enableLazyConnection();
+            } else {
+                preferences.disableLazyConnection();
+            }
+
+            showReconnectionNeededWarningDialog();
+        });
+
+        // Make parent layout clickable to toggle switch (for TV remote)
+        binding.getRoot().setOnClickListener(v -> {
+            binding.switchControl.toggle();
+        });
+    }
+
     public View onCreateView(@NonNull LayoutInflater inflater,
                              ViewGroup container, Bundle savedInstanceState) {
 
@@ -182,6 +203,7 @@ public class AdvancedFragment extends Fragment {
         });
 
         configureForceRelayConnectionSwitch(binding.layoutForceRelayConnection, preferences);
+        configureEnableLazyConnectionSwitch(binding.layoutEnableLazyConnection, preferences);
 
         // Initialize engine config switches (your settings)
         initializeEngineConfigSwitches();

--- a/app/src/main/res/layout/fragment_advanced.xml
+++ b/app/src/main/res/layout/fragment_advanced.xml
@@ -530,6 +530,17 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/layout_disable_firewall" />
 
+            <include
+                android:id="@+id/layout_enable_lazy_connection"
+                layout="@layout/component_switch"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:orientation="vertical"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/layout_force_relay_connection" />
+
             <LinearLayout
                 android:id="@+id/layout_theme"
                 android:layout_width="0dp"
@@ -538,7 +549,7 @@
                 android:orientation="vertical"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/layout_force_relay_connection">
+                app:layout_constraintTop_toBottomOf="@id/layout_enable_lazy_connection">
 
                 <TextView
                     android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,4 +141,6 @@
     <string name="profiles_success_switched">Switched to profile \'%s\'</string>
     <string name="profiles_success_logged_out">Logged out from profile \'%s\'</string>
     <string name="profiles_success_removed">Profile \'%s\' removed successfully</string>
+    <string name="advanced_enable_lazy_conn">Enable lazy connection</string>
+    <string name="advanced_enable_lazy_conn_desc">Enables lazy connection for this peer</string>
 </resources>

--- a/tool/src/main/java/io/netbird/client/tool/EnvVarPackager.java
+++ b/tool/src/main/java/io/netbird/client/tool/EnvVarPackager.java
@@ -8,6 +8,8 @@ public class EnvVarPackager {
         var envList = new EnvList();
 
         envList.put(Android.getEnvKeyNBForceRelay(), String.valueOf(preferences.isConnectionForceRelayed()));
+        envList.put(Android.getEnvKeyNBLazyConn(), String.valueOf(preferences.isLazyConnectionEnabled()));
+        envList.put(Android.getEnvKeyNBInactivityThreshold(), String.valueOf(preferences.getInactivityThreshold()));
 
         return envList;
     }

--- a/tool/src/main/java/io/netbird/client/tool/Preferences.java
+++ b/tool/src/main/java/io/netbird/client/tool/Preferences.java
@@ -8,6 +8,8 @@ public class Preferences {
     private final String keyTraceLog = "tracelog";
 
     private final String keyForceRelayConnection = "isConnectionForceRelayed";
+    private final String keyLazyConnectionEnabled = "isLazyConnectionEnabled";
+    private final String keyInactivityThreshold = "inactivityThreshold";
 
     private final SharedPreferences sharedPref;
 
@@ -36,6 +38,25 @@ public class Preferences {
 
     public void disableForcedRelayConnection() {
         sharedPref.edit().putBoolean(keyForceRelayConnection, false).apply();
+    }
+
+    public boolean isLazyConnectionEnabled() {
+        return sharedPref.getBoolean(keyLazyConnectionEnabled, true);
+    }
+
+    public void enableLazyConnection() {
+        sharedPref.edit().putBoolean(keyLazyConnectionEnabled, true).apply();
+    }
+
+    public void disableLazyConnection() {
+        sharedPref.edit().putBoolean(keyLazyConnectionEnabled, false).apply();
+    }
+
+    // This value represents for how long, in minutes, it will take for a lazy connection to be considered inactive so
+    // it won't attempt reconnection anymore. Currently, the user cannot change this so it's hardcoded to five minutes
+    // (its default value in the SDK is 15 minutes, and accepts a minimum of 1 minute).
+    public int getInactivityThreshold() {
+        return sharedPref.getInt(keyInactivityThreshold, 5);
     }
 
     public static String defaultServer() {


### PR DESCRIPTION
This PR adds a toggle in advanced settings for enabling lazy connection on the Android peer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lazy connection toggle in Advanced settings for enhanced network management
  * Introduced inactivity threshold configuration option with 5-minute default
  * Reconnection warning displays when modifying these advanced settings
  * New preferences are automatically saved and synced

<!-- end of auto-generated comment: release notes by coderabbit.ai -->