### PR TITLE
Revert ForceRelay default to false now that P2P issues are fixed

### DIFF
--- a/tool/src/main/java/io/netbird/client/tool/Preferences.java
+++ b/tool/src/main/java/io/netbird/client/tool/Preferences.java
@@ -27,7 +27,7 @@ public class Preferences {
     }
 
     public boolean isConnectionForceRelayed() {
-        return sharedPref.getBoolean(keyForceRelayConnection, true);
+        return sharedPref.getBoolean(keyForceRelayConnection, false);
     }
 
     public void enableForcedRelayConnection() {


### PR DESCRIPTION
## Summary
The default for `isConnectionForceRelayed` was set to `true` in #108 as a workaround for P2P stability issues on Android. The underlying ICE issues have since been fixed (netbirdio/netbird: guard loop fix, candidate buffering, anet for Android interface discovery), so P2P connections work reliably and should be enabled by default.

This is a one-line change: `getBoolean(keyForceRelayConnection, true)` → `getBoolean(keyForceRelayConnection, false)`.

## Checklist
- [x] Bug fix (reverts workaround now that root cause is fixed)
- [x] Documentation not needed

By submitting this pull request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the default connection relay setting to return the expected value when no preference is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Related Issues

Fixes netbirdio/android-client#130 — Android client defaults to force relay connection
Related netbirdio/netbird#5589 — Default Force Relay to Off
Related netbirdio/netbird#5672 — ICE Agent is not initialized yet on android app
