### PR TITLE
Fix foreground service type for Android 16 compatibility

### DIFF
--- a/tool/src/main/AndroidManifest.xml
+++ b/tool/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SYSTEM_EXEMPTED" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
     <application
@@ -16,7 +16,7 @@
             android:name=".VPNService"
             android:permission="android.permission.BIND_VPN_SERVICE"
             android:exported="false"
-            android:foregroundServiceType="systemExempted">
+            android:foregroundServiceType="specialUse">
             <intent-filter>
                 <action android:name="android.net.VpnService"/>
                 <action android:name="io.netbird.client.intent.action.START_SERVICE" />


### PR DESCRIPTION
## Summary
Android 16 throws `SecurityException: Starting FGS with type systemExempted` when launching the VPN foreground service. The `systemExempted` type is no longer allowed for third-party apps.

Changes:
- `foregroundServiceType`: `systemExempted` → `specialUse`
- Permission: `FOREGROUND_SERVICE_SYSTEM_EXEMPTED` → `FOREGROUND_SERVICE_SPECIAL_USE`

Tested on Samsung Galaxy S26 (Android 16).

## Checklist
- [x] Bug fix
- [x] Documentation not needed — manifest-only change

By submitting this pull request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Netbird dependency to the latest version
  * Updated Android foreground service configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->