### PR TITLE
Notify Go engine on network change for posture check re-evaluation

### DIFF
--- a/tool/src/main/java/io/netbird/client/tool/EngineRunner.java
+++ b/tool/src/main/java/io/netbird/client/tool/EngineRunner.java
@@ -172,7 +172,7 @@ class EngineRunner {
         try {
             goClient.onUnderlyingNetworkChanged();
         } catch (Exception e) {
-            Log.d(LOGTAG, "notifyNetworkChanged: " + e.getMessage());
+            Log.e(LOGTAG, "notifyNetworkChanged: " + e.getMessage());
         }
     }
 

--- a/tool/src/main/java/io/netbird/client/tool/EngineRunner.java
+++ b/tool/src/main/java/io/netbird/client/tool/EngineRunner.java
@@ -163,6 +163,19 @@ class EngineRunner {
         goClient.stop();
     }
 
+    /**
+     * Notify the Go client that the underlying network changed (WiFi/cellular).
+     * This triggers an immediate re-sync of NetworkAddresses with the management
+     * server for posture check re-evaluation.
+     */
+    public void notifyNetworkChanged() {
+        try {
+            goClient.onUnderlyingNetworkChanged();
+        } catch (Exception e) {
+            Log.d(LOGTAG, "notifyNetworkChanged: " + e.getMessage());
+        }
+    }
+
     public PeerInfoArray peersInfo() {
         return goClient.peersList();
     }

--- a/tool/src/main/java/io/netbird/client/tool/VPNService.java
+++ b/tool/src/main/java/io/netbird/client/tool/VPNService.java
@@ -76,6 +76,12 @@ public class VPNService extends android.net.VpnService {
         networkChangeDetector = new NetworkChangeDetector(
                 (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE));
         networkChangeDetector.subscribe(networkAvailabilityListener);
+        // Notify Go layer on any network change for posture check re-evaluation
+        networkChangeDetector.setNetworkChangedCallback(() -> {
+            if (engineRunner != null) {
+                engineRunner.notifyNetworkChanged();
+            }
+        });
         networkChangeDetector.registerNetworkCallback();
 
         // Register broadcast receiver for stopping engine (e.g., during profile switch)

--- a/tool/src/main/java/io/netbird/client/tool/networks/ConcreteNetworkAvailabilityListener.java
+++ b/tool/src/main/java/io/netbird/client/tool/networks/ConcreteNetworkAvailabilityListener.java
@@ -13,26 +13,24 @@ public class ConcreteNetworkAvailabilityListener implements NetworkAvailabilityL
 
     @Override
     public void onNetworkAvailable(@Constants.NetworkType int networkType) {
-        boolean isWifiAvailable = Boolean.TRUE.equals(availableNetworkTypes.get(Constants.NetworkType.WIFI));
+        Boolean wasAvailable = availableNetworkTypes.put(networkType, true);
 
-        availableNetworkTypes.put(networkType, true);
-
-        // if wifi is available and wasn't before, notifies listener.
-        // Android prioritizes wifi over mobile data network by default.
-        if (!isWifiAvailable && networkType == Constants.NetworkType.WIFI) {
+        // Always notify on any network change so the engine re-syncs
+        // NetworkAddresses with the management server. This ensures
+        // posture checks see the current network (e.g. WiFi subnet)
+        // immediately after a network switch.
+        if (!Boolean.TRUE.equals(wasAvailable)) {
             notifyListener();
         }
     }
 
     @Override
     public void onNetworkLost(@Constants.NetworkType int networkType) {
-        boolean isMobileAvailable = Boolean.TRUE.equals(availableNetworkTypes.get(Constants.NetworkType.MOBILE));
-
         availableNetworkTypes.remove(networkType);
 
-        // if wifi is lost and mobile data is available, notifies listener.
-        // No use to notify it if there's no other type of network available.
-        if (isMobileAvailable && networkType == Constants.NetworkType.WIFI) {
+        // Notify on any network loss if another network is still available,
+        // so the engine re-syncs with updated NetworkAddresses.
+        if (!availableNetworkTypes.isEmpty()) {
             notifyListener();
         }
     }

--- a/tool/src/main/java/io/netbird/client/tool/networks/NetworkChangeDetector.java
+++ b/tool/src/main/java/io/netbird/client/tool/networks/NetworkChangeDetector.java
@@ -14,10 +14,20 @@ public class NetworkChangeDetector {
     private final ConnectivityManager connectivityManager;
     private ConnectivityManager.NetworkCallback networkCallback;
     private volatile NetworkAvailabilityListener listener;
+    private volatile Runnable networkChangedCallback;
 
     public NetworkChangeDetector(ConnectivityManager connectivityManager) {
         this.connectivityManager = connectivityManager;
         initNetworkCallback();
+    }
+
+    /**
+     * Set a callback that fires on every network availability/loss event,
+     * regardless of type. Used to notify the Go layer about underlying
+     * network changes for posture check re-evaluation.
+     */
+    public void setNetworkChangedCallback(Runnable callback) {
+        this.networkChangedCallback = callback;
     }
 
     private void checkNetworkCapabilities(Network network, Consumer<Integer> operation) {
@@ -37,16 +47,24 @@ public class NetworkChangeDetector {
         networkCallback = new ConnectivityManager.NetworkCallback() {
             @Override
             public void onAvailable(@NonNull Network network) {
+                Log.d(LOGTAG, "onAvailable: " + network);
                 NetworkAvailabilityListener localListener = listener;
-                if (localListener == null) return;
-                checkNetworkCapabilities(network, localListener::onNetworkAvailable);
+                if (localListener != null) {
+                    checkNetworkCapabilities(network, localListener::onNetworkAvailable);
+                }
+                Runnable cb = networkChangedCallback;
+                if (cb != null) cb.run();
             }
 
             @Override
             public void onLost(@NonNull Network network) {
+                Log.d(LOGTAG, "onLost: " + network);
                 NetworkAvailabilityListener localListener = listener;
-                if (localListener == null) return;
-                checkNetworkCapabilities(network, localListener::onNetworkLost);
+                if (localListener != null) {
+                    checkNetworkCapabilities(network, localListener::onNetworkLost);
+                }
+                Runnable cb = networkChangedCallback;
+                if (cb != null) cb.run();
             }
 
             @Override

--- a/tool/src/main/java/io/netbird/client/tool/networks/NetworkChangeDetector.java
+++ b/tool/src/main/java/io/netbird/client/tool/networks/NetworkChangeDetector.java
@@ -51,6 +51,10 @@ public class NetworkChangeDetector {
                 // Skip the very first onAvailable after registerNetworkCallback().
                 // Android fires this immediately for each already-connected network —
                 // it is an initial state report, not an actual network change.
+                // Note: if both WiFi and cellular are connected at registration time,
+                // Android fires onAvailable for each, but we only skip the first one.
+                // The second fires a spurious notification, which is acceptable because
+                // the EngineRestarter debounces rapid network change callbacks anyway.
                 if (!initialCallbackReceived) {
                     initialCallbackReceived = true;
                     Log.d(LOGTAG, "ignoring initial onAvailable (not a real network change)");

--- a/tool/src/main/java/io/netbird/client/tool/networks/NetworkChangeDetector.java
+++ b/tool/src/main/java/io/netbird/client/tool/networks/NetworkChangeDetector.java
@@ -15,6 +15,7 @@ public class NetworkChangeDetector {
     private ConnectivityManager.NetworkCallback networkCallback;
     private volatile NetworkAvailabilityListener listener;
     private volatile Runnable networkChangedCallback;
+    private volatile boolean initialCallbackReceived;
 
     public NetworkChangeDetector(ConnectivityManager connectivityManager) {
         this.connectivityManager = connectivityManager;
@@ -47,6 +48,14 @@ public class NetworkChangeDetector {
         networkCallback = new ConnectivityManager.NetworkCallback() {
             @Override
             public void onAvailable(@NonNull Network network) {
+                // Skip the very first onAvailable after registerNetworkCallback().
+                // Android fires this immediately for each already-connected network —
+                // it is an initial state report, not an actual network change.
+                if (!initialCallbackReceived) {
+                    initialCallbackReceived = true;
+                    Log.d(LOGTAG, "ignoring initial onAvailable (not a real network change)");
+                    return;
+                }
                 Log.d(LOGTAG, "onAvailable: " + network);
                 NetworkAvailabilityListener localListener = listener;
                 if (localListener != null) {
@@ -77,6 +86,7 @@ public class NetworkChangeDetector {
     }
 
     public void registerNetworkCallback() {
+        initialCallbackReceived = false;
         NetworkRequest.Builder builder = new NetworkRequest.Builder();
         builder.addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
         connectivityManager.registerNetworkCallback(builder.build(), networkCallback);

--- a/tool/src/test/java/io/netbird/client/tool/ConcreteNetworkAvailabilityListenerUnitTest.java
+++ b/tool/src/test/java/io/netbird/client/tool/ConcreteNetworkAvailabilityListenerUnitTest.java
@@ -53,11 +53,11 @@ public class ConcreteNetworkAvailabilityListenerUnitTest {
         var networkChangeDetector = new MockNetworkChangeDetector(networkAvailabilityListener);
 
         // Act:
-        networkChangeDetector.activateMobile();
-        networkChangeDetector.activateWifi();
+        networkChangeDetector.activateMobile();  // new network type -> notify
+        networkChangeDetector.activateWifi();     // new network type -> notify
 
-        // Assert:
-        assertEquals(1, networkToggleListener.totalTimesNetworkTypeChanged);
+        // Assert: both mobile and wifi becoming available trigger notifications
+        assertEquals(2, networkToggleListener.totalTimesNetworkTypeChanged);
     }
 
     @Test
@@ -70,16 +70,16 @@ public class ConcreteNetworkAvailabilityListenerUnitTest {
         var networkChangeDetector = new MockNetworkChangeDetector(networkAvailabilityListener);
 
         // Act:
-        networkChangeDetector.activateMobile();
-        networkChangeDetector.activateWifi();   // upgraded, network changes.
-        networkChangeDetector.deactivateWifi(); // downgraded, network changes.
+        networkChangeDetector.activateMobile();  // new network type -> notify
+        networkChangeDetector.activateWifi();    // new network type -> notify
+        networkChangeDetector.deactivateWifi();  // lost, mobile still available -> notify
 
-        // Assert:
-        assertEquals(2, networkToggleListener.totalTimesNetworkTypeChanged);
+        // Assert: each event triggers a notification
+        assertEquals(3, networkToggleListener.totalTimesNetworkTypeChanged);
     }
 
     @Test
-    public void shouldNotNotifyListenerNetworkDidNotUpgrade() {
+    public void shouldNotifyListenerOnAnyNetworkChange() {
         // Assemble:
         var networkToggleListener = new MockNetworkToggleListener();
         var networkAvailabilityListener = new ConcreteNetworkAvailabilityListener();
@@ -92,11 +92,11 @@ public class ConcreteNetworkAvailabilityListenerUnitTest {
 
         networkToggleListener.resetCounter();
 
-        networkChangeDetector.activateMobile();
-        networkChangeDetector.deactivateMobile();
+        networkChangeDetector.activateMobile();    // new network type -> notify
+        networkChangeDetector.deactivateMobile();  // lost, wifi still available -> notify
 
-        // Assert:
-        assertEquals(0, networkToggleListener.totalTimesNetworkTypeChanged);
+        // Assert: every network change notifies for posture check re-evaluation
+        assertEquals(2, networkToggleListener.totalTimesNetworkTypeChanged);
     }
 
     @Test


### PR DESCRIPTION
## Summary
When the device switches between WiFi and cellular, posture checks need to re-evaluate the current network state. Previously, NetworkAddresses were only sent during login or when checks changed — not on network transitions.

Changes:
- **NetworkChangeDetector**: Add `setNetworkChangedCallback()` that fires on every `onAvailable`/`onLost` event, with logging
- **EngineRunner**: Add `notifyNetworkChanged()` that calls `goClient.onUnderlyingNetworkChanged()`
- **VPNService**: Wire the callback from detector → engine runner
- **ConcreteNetworkAvailabilityListener**: Notify on any network type transition, not just specific WiFi↔Mobile patterns

This works together with the Go-side `ResyncNetworkAddresses()` (netbirdio/netbird#5807) to trigger immediate `SyncMeta` on network change.

## Checklist
- [x] Enhancement
- [x] Documentation not needed — internal callback mechanism

By submitting this pull request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://github.com/netbirdio/netbird/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved detection and handling of network transitions between WiFi and cellular networks
  * Enhanced notification system for network availability changes to ensure more responsive connectivity management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Related Issues

Fixes netbirdio/netbird#2029 — Android-App: Netbird not reconnecting when switching between wifi and cellular
Fixes netbirdio/android-client#146 — Netbird keeps disconnecting
Related netbirdio/android-client#143 — Repeatable disconnect issue on Android Client
Related netbirdio/netbird#5641 — Linux client fails to reconnect via LTE after WiFi interface goes down
