### PR TITLE
feat: add MDM managed app configuration support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,10 @@
         android:theme="@style/Theme.NetBird"
         tools:targetApi="31">
 
+        <meta-data
+            android:name="android.content.APP_RESTRICTIONS"
+            android:resource="@xml/app_restrictions" />
+
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTask"
@@ -55,6 +59,14 @@
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
         </service>
+
+        <receiver
+            android:name="io.netbird.client.tool.ManagedConfigReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.APPLICATION_RESTRICTIONS_CHANGED" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -145,4 +145,20 @@
     <string name="profiles_success_switched">Switched to profile \'%s\'</string>
     <string name="profiles_success_logged_out">Logged out from profile \'%s\'</string>
     <string name="profiles_success_removed">Profile \'%s\' removed successfully</string>
+
+    <!-- MDM managed configuration (app restrictions) titles and descriptions -->
+    <string name="mdm_management_url_title">Management URL</string>
+    <string name="mdm_management_url_desc">NetBird management server URL (e.g., https://api.netbird.io:443)</string>
+    <string name="mdm_setup_key_title">Setup Key</string>
+    <string name="mdm_setup_key_desc">Setup key for automatic device registration. Used once during initial enrollment.</string>
+    <string name="mdm_admin_url_title">Admin URL</string>
+    <string name="mdm_admin_url_desc">NetBird admin dashboard URL (e.g., https://app.netbird.io:443)</string>
+    <string name="mdm_pre_shared_key_title">Pre-Shared Key</string>
+    <string name="mdm_pre_shared_key_desc">WireGuard pre-shared key for additional encryption layer</string>
+    <string name="mdm_rosenpass_enabled_title">Enable Rosenpass</string>
+    <string name="mdm_rosenpass_enabled_desc">Enable Rosenpass post-quantum encryption</string>
+    <string name="mdm_rosenpass_permissive_title">Rosenpass Permissive Mode</string>
+    <string name="mdm_rosenpass_permissive_desc">Allow connections to peers that do not support Rosenpass</string>
+    <string name="mdm_disable_auto_connect_title">Disable Auto-Connect</string>
+    <string name="mdm_disable_auto_connect_desc">Prevent the VPN from automatically connecting on app launch</string>
 </resources>

--- a/app/src/main/res/xml/app_restrictions.xml
+++ b/app/src/main/res/xml/app_restrictions.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Android Enterprise Managed Configurations (App Restrictions) schema.
+  This defines the configuration keys that MDM/EMM solutions can push to the app.
+  Follows the AppConfig standard (appconfig.org) for key naming conventions.
+
+  Supported MDM platforms: Microsoft Intune, VMware Workspace ONE, Google Admin Console,
+  MobileIron, and any Android Enterprise-compatible EMM.
+-->
+<restrictions xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <restriction
+        android:key="managementUrl"
+        android:title="Management URL"
+        android:description="NetBird management server URL (e.g., https://api.netbird.io:443)"
+        android:restrictionType="string"
+        android:defaultValue="" />
+
+    <restriction
+        android:key="setupKey"
+        android:title="Setup Key"
+        android:description="Setup key for automatic device registration. Used once during initial enrollment."
+        android:restrictionType="string"
+        android:defaultValue="" />
+
+    <restriction
+        android:key="adminUrl"
+        android:title="Admin URL"
+        android:description="NetBird admin dashboard URL (e.g., https://app.netbird.io:443)"
+        android:restrictionType="string"
+        android:defaultValue="" />
+
+    <restriction
+        android:key="preSharedKey"
+        android:title="Pre-Shared Key"
+        android:description="WireGuard pre-shared key for additional encryption layer"
+        android:restrictionType="string"
+        android:defaultValue="" />
+
+    <restriction
+        android:key="rosenpassEnabled"
+        android:title="Enable Rosenpass"
+        android:description="Enable Rosenpass post-quantum encryption"
+        android:restrictionType="bool"
+        android:defaultValue="false" />
+
+    <restriction
+        android:key="rosenpassPermissive"
+        android:title="Rosenpass Permissive Mode"
+        android:description="Allow connections to peers that do not support Rosenpass"
+        android:restrictionType="bool"
+        android:defaultValue="false" />
+
+    <restriction
+        android:key="disableAutoConnect"
+        android:title="Disable Auto-Connect"
+        android:description="Prevent the VPN from automatically connecting on app launch"
+        android:restrictionType="bool"
+        android:defaultValue="false" />
+
+</restrictions>

--- a/app/src/main/res/xml/app_restrictions.xml
+++ b/app/src/main/res/xml/app_restrictions.xml
@@ -11,50 +11,50 @@
 
     <restriction
         android:key="managementUrl"
-        android:title="Management URL"
-        android:description="NetBird management server URL (e.g., https://api.netbird.io:443)"
+        android:title="@string/mdm_management_url_title"
+        android:description="@string/mdm_management_url_desc"
         android:restrictionType="string"
         android:defaultValue="" />
 
     <restriction
         android:key="setupKey"
-        android:title="Setup Key"
-        android:description="Setup key for automatic device registration. Used once during initial enrollment."
+        android:title="@string/mdm_setup_key_title"
+        android:description="@string/mdm_setup_key_desc"
         android:restrictionType="string"
         android:defaultValue="" />
 
     <restriction
         android:key="adminUrl"
-        android:title="Admin URL"
-        android:description="NetBird admin dashboard URL (e.g., https://app.netbird.io:443)"
+        android:title="@string/mdm_admin_url_title"
+        android:description="@string/mdm_admin_url_desc"
         android:restrictionType="string"
         android:defaultValue="" />
 
     <restriction
         android:key="preSharedKey"
-        android:title="Pre-Shared Key"
-        android:description="WireGuard pre-shared key for additional encryption layer"
+        android:title="@string/mdm_pre_shared_key_title"
+        android:description="@string/mdm_pre_shared_key_desc"
         android:restrictionType="string"
         android:defaultValue="" />
 
     <restriction
         android:key="rosenpassEnabled"
-        android:title="Enable Rosenpass"
-        android:description="Enable Rosenpass post-quantum encryption"
+        android:title="@string/mdm_rosenpass_enabled_title"
+        android:description="@string/mdm_rosenpass_enabled_desc"
         android:restrictionType="bool"
         android:defaultValue="false" />
 
     <restriction
         android:key="rosenpassPermissive"
-        android:title="Rosenpass Permissive Mode"
-        android:description="Allow connections to peers that do not support Rosenpass"
+        android:title="@string/mdm_rosenpass_permissive_title"
+        android:description="@string/mdm_rosenpass_permissive_desc"
         android:restrictionType="bool"
         android:defaultValue="false" />
 
     <restriction
         android:key="disableAutoConnect"
-        android:title="Disable Auto-Connect"
-        android:description="Prevent the VPN from automatically connecting on app launch"
+        android:title="@string/mdm_disable_auto_connect_title"
+        android:description="@string/mdm_disable_auto_connect_desc"
         android:restrictionType="bool"
         android:defaultValue="false" />
 

--- a/tool/src/main/java/io/netbird/client/tool/EngineRunner.java
+++ b/tool/src/main/java/io/netbird/client/tool/EngineRunner.java
@@ -23,6 +23,12 @@ import io.netbird.gomobile.android.URLOpener;
 class EngineRunner {
 
     private static final String LOGTAG = "EngineRunner";
+
+    /**
+     * Lock to serialise MDM config apply operations between EngineRunner.runClient()
+     * and ManagedConfigReceiver.onReceive().
+     */
+    static final Object MDM_CONFIG_LOCK = new Object();
     private final Context context;
     private final boolean isDebuggable;
     private final ProfileManagerWrapper profileManager;
@@ -97,25 +103,33 @@ class EngineRunner {
             // Apply MDM managed configuration before starting the engine.
             // MDM values override user-set preferences on every launch.
             try {
-                io.netbird.gomobile.android.ManagedConfig mdmConfig = ManagedConfigReader.read(context);
-                if (mdmConfig != null && mdmConfig.hasConfig()) {
-                    mdmConfig.apply(configurationFilePath);
-                    Log.i(LOGTAG, "MDM managed configuration applied");
+                synchronized (MDM_CONFIG_LOCK) {
+                    io.netbird.gomobile.android.ManagedConfig mdmConfig = ManagedConfigReader.read(context);
+                    if (mdmConfig != null && mdmConfig.hasConfig()) {
+                        mdmConfig.apply(configurationFilePath);
+                        Log.i(LOGTAG, "MDM managed configuration applied");
 
-                    // If MDM provides a setup key and the engine needs login,
-                    // perform silent registration with the setup key
-                    if (mdmConfig.hasSetupKey()) {
-                        try {
-                            io.netbird.gomobile.android.Auth auth =
-                                    io.netbird.gomobile.android.Android.newAuth(configurationFilePath, "");
-                            if (auth != null) {
-                                auth.loginWithSetupKeySync(mdmConfig.getSetupKey(), DeviceName.getDeviceName());
-                                Log.i(LOGTAG, "MDM: silent setup key registration completed");
+                        // If MDM provides a setup key, attempt silent registration.
+                        // loginWithSetupKeySync will call the management server which
+                        // returns success (already registered) or registers the peer.
+                        // The server is the authority — no local enrollment flag needed.
+                        if (mdmConfig.hasSetupKey()) {
+                            try {
+                                io.netbird.gomobile.android.Auth auth =
+                                        io.netbird.gomobile.android.Android.newAuth(
+                                                configurationFilePath,
+                                                mdmConfig.getSetupKey());
+                                if (auth != null) {
+                                    auth.loginWithSetupKeySync(
+                                            mdmConfig.getSetupKey(),
+                                            DeviceName.getDeviceName());
+                                    Log.i(LOGTAG, "MDM: silent setup key registration completed");
+                                }
+                            } catch (Exception e) {
+                                // Setup key login may fail if already registered or key expired.
+                                // This is not fatal — continue with normal flow.
+                                Log.w(LOGTAG, "MDM: setup key login skipped or failed: " + e.getMessage());
                             }
-                        } catch (Exception e) {
-                            // Setup key login may fail if already registered or key expired.
-                            // This is not fatal — continue with normal flow.
-                            Log.w(LOGTAG, "MDM: setup key login skipped or failed: " + e.getMessage());
                         }
                     }
                 }

--- a/tool/src/main/java/io/netbird/client/tool/EngineRunner.java
+++ b/tool/src/main/java/io/netbird/client/tool/EngineRunner.java
@@ -118,7 +118,7 @@ class EngineRunner {
                                 io.netbird.gomobile.android.Auth auth =
                                         io.netbird.gomobile.android.Android.newAuth(
                                                 configurationFilePath,
-                                                mdmConfig.getSetupKey());
+                                                mdmConfig.getManagementURL());
                                 if (auth != null) {
                                     auth.loginWithSetupKeySync(
                                             mdmConfig.getSetupKey(),

--- a/tool/src/main/java/io/netbird/client/tool/EngineRunner.java
+++ b/tool/src/main/java/io/netbird/client/tool/EngineRunner.java
@@ -94,6 +94,35 @@ class EngineRunner {
             var platformFiles = new AndroidPlatformFiles(configurationFilePath, stateFilePath, context.getCacheDir().getAbsolutePath());
             Log.d(LOGTAG, "Running engine with config: " + configurationFilePath + ", state: " + stateFilePath);
 
+            // Apply MDM managed configuration before starting the engine.
+            // MDM values override user-set preferences on every launch.
+            try {
+                io.netbird.gomobile.android.ManagedConfig mdmConfig = ManagedConfigReader.read(context);
+                if (mdmConfig != null && mdmConfig.hasConfig()) {
+                    mdmConfig.apply(configurationFilePath);
+                    Log.i(LOGTAG, "MDM managed configuration applied");
+
+                    // If MDM provides a setup key and the engine needs login,
+                    // perform silent registration with the setup key
+                    if (mdmConfig.hasSetupKey()) {
+                        try {
+                            io.netbird.gomobile.android.Auth auth =
+                                    io.netbird.gomobile.android.Android.newAuth(configurationFilePath, "");
+                            if (auth != null) {
+                                auth.loginWithSetupKeySync(mdmConfig.getSetupKey(), DeviceName.getDeviceName());
+                                Log.i(LOGTAG, "MDM: silent setup key registration completed");
+                            }
+                        } catch (Exception e) {
+                            // Setup key login may fail if already registered or key expired.
+                            // This is not fatal — continue with normal flow.
+                            Log.w(LOGTAG, "MDM: setup key login skipped or failed: " + e.getMessage());
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                Log.e(LOGTAG, "Failed to apply MDM config, continuing with existing config", e);
+            }
+
             try {
                 notifyServiceStateListeners(true);
                 if (urlOpener == null) {

--- a/tool/src/main/java/io/netbird/client/tool/ManagedConfigReader.java
+++ b/tool/src/main/java/io/netbird/client/tool/ManagedConfigReader.java
@@ -1,0 +1,120 @@
+package io.netbird.client.tool;
+
+import android.content.Context;
+import android.content.RestrictionsManager;
+import android.os.Bundle;
+import android.util.Log;
+
+import io.netbird.gomobile.android.Android;
+import io.netbird.gomobile.android.ManagedConfig;
+
+/**
+ * Reads MDM-managed configuration from Android Enterprise managed configurations
+ * (app restrictions). Configuration is pushed by EMM/MDM solutions such as
+ * Microsoft Intune, VMware Workspace ONE, or Google Admin Console.
+ *
+ * <p>The key names match those defined in res/xml/app_restrictions.xml and the
+ * Go SDK's ManagedConfig key constants.</p>
+ */
+public class ManagedConfigReader {
+
+    private static final String TAG = "ManagedConfigReader";
+
+    private ManagedConfigReader() {
+        // utility class
+    }
+
+    /**
+     * Reads managed configuration from RestrictionsManager and returns a populated
+     * ManagedConfig instance. Returns null if no managed configuration is available
+     * or the RestrictionsManager service is unavailable.
+     *
+     * @param context Android context
+     * @return populated ManagedConfig, or null if no MDM config is present
+     */
+    public static ManagedConfig read(Context context) {
+        RestrictionsManager restrictionsManager =
+                (RestrictionsManager) context.getSystemService(Context.RESTRICTIONS_SERVICE);
+        if (restrictionsManager == null) {
+            Log.d(TAG, "RestrictionsManager not available");
+            return null;
+        }
+
+        Bundle restrictions = restrictionsManager.getApplicationRestrictions();
+        if (restrictions == null || restrictions.isEmpty()) {
+            Log.d(TAG, "No managed configuration found");
+            return null;
+        }
+
+        ManagedConfig config = Android.newManagedConfig();
+
+        String managementUrl = restrictions.getString(
+                Android.getManagedConfigKeyManagementURL(), "");
+        if (!managementUrl.isEmpty()) {
+            config.setManagementURL(managementUrl);
+            Log.i(TAG, "MDM: management URL configured");
+        }
+
+        String setupKey = restrictions.getString(
+                Android.getManagedConfigKeySetupKey(), "");
+        if (!setupKey.isEmpty()) {
+            config.setSetupKey(setupKey);
+            // Do not log the setup key value for security
+            Log.i(TAG, "MDM: setup key configured");
+        }
+
+        String adminUrl = restrictions.getString(
+                Android.getManagedConfigKeyAdminURL(), "");
+        if (!adminUrl.isEmpty()) {
+            config.setAdminURL(adminUrl);
+            Log.i(TAG, "MDM: admin URL configured");
+        }
+
+        String preSharedKey = restrictions.getString(
+                Android.getManagedConfigKeyPreSharedKey(), "");
+        if (!preSharedKey.isEmpty()) {
+            config.setPreSharedKey(preSharedKey);
+            Log.i(TAG, "MDM: pre-shared key configured");
+        }
+
+        if (restrictions.containsKey(Android.getManagedConfigKeyRosenpassEnabled())) {
+            boolean rosenpassEnabled = restrictions.getBoolean(
+                    Android.getManagedConfigKeyRosenpassEnabled(), false);
+            config.setRosenpassEnabled(rosenpassEnabled);
+            Log.i(TAG, "MDM: Rosenpass enabled=" + rosenpassEnabled);
+        }
+
+        if (restrictions.containsKey(Android.getManagedConfigKeyRosenpassPermissive())) {
+            boolean rosenpassPermissive = restrictions.getBoolean(
+                    Android.getManagedConfigKeyRosenpassPermissive(), false);
+            config.setRosenpassPermissive(rosenpassPermissive);
+            Log.i(TAG, "MDM: Rosenpass permissive=" + rosenpassPermissive);
+        }
+
+        if (restrictions.containsKey(Android.getManagedConfigKeyDisableAutoConnect())) {
+            boolean disableAutoConnect = restrictions.getBoolean(
+                    Android.getManagedConfigKeyDisableAutoConnect(), false);
+            config.setDisableAutoConnect(disableAutoConnect);
+            Log.i(TAG, "MDM: disable auto-connect=" + disableAutoConnect);
+        }
+
+        if (!config.hasConfig()) {
+            Log.d(TAG, "MDM restrictions present but no NetBird keys configured");
+            return null;
+        }
+
+        Log.i(TAG, "MDM managed configuration loaded successfully");
+        return config;
+    }
+
+    /**
+     * Returns true if any MDM-managed configuration is available for this app.
+     *
+     * @param context Android context
+     * @return true if managed config has values
+     */
+    public static boolean hasManagedConfig(Context context) {
+        ManagedConfig config = read(context);
+        return config != null && config.hasConfig();
+    }
+}

--- a/tool/src/main/java/io/netbird/client/tool/ManagedConfigReceiver.java
+++ b/tool/src/main/java/io/netbird/client/tool/ManagedConfigReceiver.java
@@ -5,6 +5,9 @@ import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 import io.netbird.gomobile.android.ManagedConfig;
 
 /**
@@ -12,15 +15,15 @@ import io.netbird.gomobile.android.ManagedConfig;
  * when the MDM/EMM pushes updated managed configuration to the device.
  *
  * <p>This receiver re-reads the managed configuration and applies it to the
- * Go SDK config file. If the VPN engine is running and the management URL changed,
- * the engine should be restarted (handled by the EngineRunner via its existing
- * restart mechanism).</p>
+ * Go SDK config file. Work is performed off the main thread via {@code goAsync()}
+ * to avoid ANRs.</p>
  *
  * <p>Register this receiver in AndroidManifest.xml or dynamically in the VPNService.</p>
  */
 public class ManagedConfigReceiver extends BroadcastReceiver {
 
     private static final String TAG = "ManagedConfigReceiver";
+    private static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
 
     @Override
     public void onReceive(Context context, Intent intent) {
@@ -30,19 +33,26 @@ public class ManagedConfigReceiver extends BroadcastReceiver {
 
         Log.i(TAG, "Application restrictions changed, re-reading MDM config");
 
-        ManagedConfig config = ManagedConfigReader.read(context);
-        if (config == null || !config.hasConfig()) {
-            Log.d(TAG, "No MDM config after restrictions change");
-            return;
-        }
+        final PendingResult pendingResult = goAsync();
+        EXECUTOR.execute(() -> {
+            try {
+                synchronized (EngineRunner.MDM_CONFIG_LOCK) {
+                    ManagedConfig config = ManagedConfigReader.read(context);
+                    if (config == null || !config.hasConfig()) {
+                        Log.d(TAG, "No MDM config after restrictions change");
+                        return;
+                    }
 
-        try {
-            ProfileManagerWrapper profileManager = new ProfileManagerWrapper(context);
-            String configPath = profileManager.getActiveConfigPath();
-            config.apply(configPath);
-            Log.i(TAG, "MDM config re-applied after restrictions change");
-        } catch (Exception e) {
-            Log.e(TAG, "Failed to apply MDM config after restrictions change", e);
-        }
+                    ProfileManagerWrapper profileManager = new ProfileManagerWrapper(context);
+                    String configPath = profileManager.getActiveConfigPath();
+                    config.apply(configPath);
+                    Log.i(TAG, "MDM config re-applied after restrictions change");
+                }
+            } catch (Exception e) {
+                Log.e(TAG, "Failed to apply MDM config after restrictions change", e);
+            } finally {
+                pendingResult.finish();
+            }
+        });
     }
 }

--- a/tool/src/main/java/io/netbird/client/tool/ManagedConfigReceiver.java
+++ b/tool/src/main/java/io/netbird/client/tool/ManagedConfigReceiver.java
@@ -1,0 +1,48 @@
+package io.netbird.client.tool;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+import io.netbird.gomobile.android.ManagedConfig;
+
+/**
+ * Receives {@code Intent.ACTION_APPLICATION_RESTRICTIONS_CHANGED} broadcasts
+ * when the MDM/EMM pushes updated managed configuration to the device.
+ *
+ * <p>This receiver re-reads the managed configuration and applies it to the
+ * Go SDK config file. If the VPN engine is running and the management URL changed,
+ * the engine should be restarted (handled by the EngineRunner via its existing
+ * restart mechanism).</p>
+ *
+ * <p>Register this receiver in AndroidManifest.xml or dynamically in the VPNService.</p>
+ */
+public class ManagedConfigReceiver extends BroadcastReceiver {
+
+    private static final String TAG = "ManagedConfigReceiver";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (!Intent.ACTION_APPLICATION_RESTRICTIONS_CHANGED.equals(intent.getAction())) {
+            return;
+        }
+
+        Log.i(TAG, "Application restrictions changed, re-reading MDM config");
+
+        ManagedConfig config = ManagedConfigReader.read(context);
+        if (config == null || !config.hasConfig()) {
+            Log.d(TAG, "No MDM config after restrictions change");
+            return;
+        }
+
+        try {
+            ProfileManagerWrapper profileManager = new ProfileManagerWrapper(context);
+            String configPath = profileManager.getActiveConfigPath();
+            config.apply(configPath);
+            Log.i(TAG, "MDM config re-applied after restrictions change");
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to apply MDM config after restrictions change", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add Android Enterprise managed configurations support, allowing MDM solutions (Intune, Google Workspace, etc.) to push NetBird configuration to managed devices for zero-touch deployment.

Related to netbirdio/netbird#1918

## Changes

- **`app/src/main/res/xml/app_restrictions.xml`** — Android Enterprise managed configuration schema defining 7 keys: `managementUrl`, `setupKey`, `adminUrl`, `preSharedKey`, `rosenpassEnabled`, `rosenpassPermissive`, `disableAutoConnect`
- **`app/src/main/AndroidManifest.xml`** — Registered `APP_RESTRICTIONS` metadata and `ManagedConfigReceiver` broadcast receiver
- **`tool/.../ManagedConfigReader.java`** — Reads MDM config from `RestrictionsManager.getApplicationRestrictions()` into Go SDK `ManagedConfig`
- **`tool/.../ManagedConfigReceiver.java`** — `BroadcastReceiver` for `ACTION_APPLICATION_RESTRICTIONS_CHANGED` to handle runtime MDM updates
- **`tool/.../EngineRunner.java`** — Applies MDM config and auto-login with setup key before VPN engine start

## How It Works

1. MDM pushes managed configuration via Android Enterprise
2. On VPN service start, `ManagedConfigReader` reads from `RestrictionsManager`
3. Config is applied to NetBird client configuration (overrides user settings)
4. If a setup key is provided, automatic enrollment is attempted
5. Runtime config changes are handled via `ManagedConfigReceiver`

## Dependencies

- Requires Go SDK changes from netbirdio/netbird#5986

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Mobile Device Management (MDM) support for managed app configuration and seven configurable keys (management/admin URLs, setup key, pre-shared key, Rosenpass toggles, disable-auto-connect).
  * App can automatically apply updated managed settings when they change.
  * Silent setup-key registration attempt during startup if a setup key is provided.
  * New user-facing labels and descriptions for all MDM options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->