### PR TITLE
Add Lazy connection toggle to Advanced settings

### DIFF
--- a/app/src/main/java/io/netbird/client/ui/advanced/AdvancedFragment.java
+++ b/app/src/main/java/io/netbird/client/ui/advanced/AdvancedFragment.java
@@ -197,6 +197,7 @@ public class AdvancedFragment extends Fragment {
             binding.switchDisableFirewall.setChecked(goPreferences.getDisableFirewall());
             binding.switchAllowSsh.setChecked(goPreferences.getServerSSHAllowed());
             binding.switchBlockInbound.setChecked(goPreferences.getBlockInbound());
+            binding.switchLazyConnection.setChecked(goPreferences.getLazyConnectionEnabled());
 
             // Set up change listeners
             binding.switchDisableClientRoutes.setOnCheckedChangeListener((buttonView, isChecked) -> {
@@ -252,14 +253,27 @@ public class AdvancedFragment extends Fragment {
                     Log.e(LOGTAG, "Failed to set block inbound", e);
                 }
             });
-            
+
+            binding.switchLazyConnection.setOnCheckedChangeListener((buttonView, isChecked) -> {
+                try {
+                    goPreferences.setLazyConnectionEnabled(isChecked);
+                    goPreferences.commit();
+                } catch (Exception e) {
+                    Log.e(LOGTAG, "Failed to set lazy connection", e);
+                }
+            });
+
             // Make parent layouts clickable to toggle switches (for TV remote)
             binding.layoutAllowSsh.setOnClickListener(v -> {
                 binding.switchAllowSsh.toggle();
             });
-            
+
             binding.layoutBlockInbound.setOnClickListener(v -> {
                 binding.switchBlockInbound.toggle();
+            });
+
+            binding.layoutLazyConnection.setOnClickListener(v -> {
+                binding.switchLazyConnection.toggle();
             });
             
             binding.layoutDisableClientRoutes.setOnClickListener(v -> {

--- a/app/src/main/res/layout/fragment_advanced.xml
+++ b/app/src/main/res/layout/fragment_advanced.xml
@@ -268,7 +268,7 @@
             </LinearLayout>
 
             <LinearLayout
-                android:id="@+id/layout_disable_client_routes"
+                android:id="@+id/layout_lazy_connection"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
@@ -281,6 +281,55 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/layout_block_inbound">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/advanced_lazy_connection"
+                        android:textColor="@color/nb_txt_light" />
+
+                    <com.google.android.material.switchmaterial.SwitchMaterial
+                        android:id="@+id/switch_lazy_connection"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:clickable="false"
+                        android:focusable="false" />
+
+                </LinearLayout>
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="0dp"
+                    android:layout_marginTop="2dp"
+                    android:layout_marginEnd="48dp"
+                    android:text="@string/advanced_lazy_connection_desc"
+                    android:textColor="@color/nb_txt_light"
+                    android:textSize="12sp" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/layout_disable_client_routes"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:background="@drawable/focus_highlight"
+                android:clickable="true"
+                android:focusable="true"
+                android:focusableInTouchMode="false"
+                android:orientation="vertical"
+                android:padding="12dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/layout_lazy_connection">
 
                 <LinearLayout
                     android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,6 +96,8 @@
     <string name="advanced_allow_ssh_desc">Allows SSH connections to this device</string>
     <string name="advanced_block_inbound">Block inbound connections</string>
     <string name="advanced_block_inbound_desc">Blocks all inbound connections to this device and routed networks. This overrides any policies received from the management service</string>
+    <string name="advanced_lazy_connection">Lazy connection</string>
+    <string name="advanced_lazy_connection_desc">Defer per-peer connection setup until first actual traffic. Reduces background load but adds latency to the first packet to a peer</string>
 
 
     <string name="desc_logo">NetBird logo</string>


### PR DESCRIPTION
## Describe your changes

Adds a "Lazy connection" switch to the Advanced settings fragment (sits between *Block inbound connections* and *Disable client routes*). The toggle controls the engine's `LazyConnectionEnabled` setting via the gomobile `Preferences` bridge.

- New `layout_lazy_connection` block in `fragment_advanced.xml`; the constraint chain is updated so `layout_disable_client_routes` is anchored below the new block.
- New string resources `advanced_lazy_connection` / `advanced_lazy_connection_desc`.
- `AdvancedFragment.initializeEngineConfigSwitches()` reads the current value via `goPreferences.getLazyConnectionEnabled()` and writes back via `setLazyConnectionEnabled()` + `commit()` on toggle, with a TV-remote layout click handler wired through `layout_lazy_connection.toggle()`.

Default is **off**, so behavior on existing installs does not change until a user enables it explicitly.

## Issue ticket number and link

N/A.

## Checklist

- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible) — N/A, UI passthrough.
- [x] Extended the README / documentation, if necessary

## Dependency

This PR consumes two new bridge methods on the gomobile `Preferences` type:
- `GetLazyConnectionEnabled() (bool, error)`
- `SetLazyConnectionEnabled(enabled bool)`

Those are added in **netbirdio/netbird#5994**. This PR's submodule pointer is intentionally **not** bumped — it should land after #5994 merges, at which point a routine submodule update will pick up the new bridge symbols and this PR will compile.

## Testing

Verified end-to-end on a Galaxy S21 (SM-G991B, Android 15) with a local build that includes the bridge change:

- `aapt2 dump resources` confirms `id/layout_lazy_connection`, `id/switch_lazy_connection`, `string/advanced_lazy_connection` are baked into the APK.
- `dexdump` confirms `AdvancedFragment` calls `Preferences.{get,set}LazyConnectionEnabled`.
- After toggling the switch on and reconnecting, GoLog logcat confirms the engine activates the lazy-connection subsystem:
  - `client/internal/lazyconn/manager/manager.go: setup lazy connection service`
  - `client/internal/lazyconn/inactivity/manager.go: inactivity threshold configured: 15m0s`
  - `client/internal/conn_mgr.go: peer added to lazy conn manager` (per peer)
  - `client/internal/lazyconn/activity/listener_udp.go: created activity listener: 127.0.0.1:NNNNN`
  - On peer activity: `removing activity listener` → `adding peer to inactivity manager`
- With the toggle off, the same logcat shows: `client/internal/conn_mgr.go: lazy connection manager is disabled`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced lazy connection setting in advanced settings, which defers per-peer connection establishment until first actual traffic occurs. The setting automatically persists and provides a user-friendly toggle control accessible through both touch and remote controls, optimizing network resource usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->