### PR TITLE
Fix outdated Slack URL in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,7 @@
      <a href="https://github.com/netbirdio/netbird/blob/main/LICENSE">
        <img height="20" src="https://www.gnu.org/graphics/gplv3-88x31.png" />
      </a>
-    <a href="https://join.slack.com/t/netbirdio/shared_invite/zt-vrahf41g-ik1v7fV8du6t0RwxSrJ96A">
+    <a href="https://docs.netbird.io/slack-url">
         <img src="https://img.shields.io/badge/slack-@netbird-red.svg?logo=slack"/>
      </a>    
   </p>
@@ -20,7 +20,7 @@
   <br/>
   See <a href="https://netbird.io/docs/">Documentation</a>
   <br/>
-   Join our <a href="https://join.slack.com/t/netbirdio/shared_invite/zt-vrahf41g-ik1v7fV8du6t0RwxSrJ96A">Slack channel</a>
+   Join our <a href="https://docs.netbird.io/slack-url">Slack channel</a>
   <br/>
 
 </strong>


### PR DESCRIPTION
With the current link in the README, you're redirected to a page saying that the link is outdated:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/619392b2-cc5a-47dd-a845-467c042207b9" />

Checking the `netbirdio/netbird` repo, they're using a docs URL which forwards to a working Slack invite: https://github.com/netbirdio/netbird/blob/946ce4c3da24126ae34cc3b482277923863cbddb/README.md?plain=1#L16

This PR updates the Android client repo README to use the same Slack link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Slack community links to direct users to the new documentation portal.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/android-client/pull/180)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->