### PR TITLE
Mdm integration

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,13 @@
         android:theme="@style/Theme.NetBird"
         tools:targetApi="31">
 
+        <!-- Managed-configuration schema. Read by Device Owner / Profile
+             Owner controllers (Intune, MobileIron, TestDPC, etc.) so the
+             admin UI can render proper inputs for each MDM-managed key. -->
+        <meta-data
+            android:name="android.content.APP_RESTRICTIONS"
+            android:resource="@xml/app_restrictions" />
+
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTask"

--- a/app/src/main/java/io/netbird/client/MDMPolicyFetcher.java
+++ b/app/src/main/java/io/netbird/client/MDMPolicyFetcher.java
@@ -1,0 +1,69 @@
+package io.netbird.client;
+
+import android.content.Context;
+import android.content.RestrictionsManager;
+import android.os.Bundle;
+import android.util.Log;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import io.netbird.gomobile.android.PolicyFetcher;
+
+/**
+ * MDMPolicyFetcher reads the current Android managed-config snapshot from
+ * RestrictionsManager and returns it as a JSON-encoded string to the Go
+ * layer. Registered once at app start via Android.setMobilePolicyFetcher;
+ * the Go side invokes fetchJSON() on every LoadPolicy call so the response
+ * is always fresh.
+ *
+ * Returns an empty string when no managed config is set — the daemon side
+ * treats that as the "no MDM source present" sentinel.
+ */
+public class MDMPolicyFetcher implements PolicyFetcher {
+    private static final String TAG = "MDMPolicyFetcher";
+
+    private final Context context;
+
+    public MDMPolicyFetcher(Context context) {
+        this.context = context.getApplicationContext();
+    }
+
+    @Override
+    public String fetchJSON() {
+        RestrictionsManager rm = (RestrictionsManager) context.getSystemService(Context.RESTRICTIONS_SERVICE);
+        if (rm == null) {
+            return "";
+        }
+        Bundle restrictions = rm.getApplicationRestrictions();
+        if (restrictions == null || restrictions.isEmpty()) {
+            return "";
+        }
+        try {
+            return bundleToJSON(restrictions).toString();
+        } catch (JSONException e) {
+            Log.w(TAG, "Failed to serialize managed restrictions to JSON: " + e);
+            return "";
+        }
+    }
+
+    private static JSONObject bundleToJSON(Bundle bundle) throws JSONException {
+        JSONObject obj = new JSONObject();
+        for (String key : bundle.keySet()) {
+            Object value = bundle.get(key);
+            if (value instanceof Bundle) {
+                obj.put(key, bundleToJSON((Bundle) value));
+            } else if (value instanceof Object[]) {
+                JSONArray arr = new JSONArray();
+                for (Object item : (Object[]) value) {
+                    arr.put(item);
+                }
+                obj.put(key, arr);
+            } else {
+                obj.put(key, value);
+            }
+        }
+        return obj;
+    }
+}

--- a/app/src/main/java/io/netbird/client/MyApplication.java
+++ b/app/src/main/java/io/netbird/client/MyApplication.java
@@ -5,8 +5,6 @@ import android.content.SharedPreferences;
 
 import androidx.appcompat.app.AppCompatDelegate;
 
-import io.netbird.gomobile.android.Android;
-
 public class MyApplication extends Application {
 
     @Override
@@ -17,9 +15,9 @@ public class MyApplication extends Application {
         int themeMode = prefs.getInt("theme_mode", AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM);
         AppCompatDelegate.setDefaultNightMode(themeMode);
 
-        // Register the MDM policy fetcher exactly once for the process
-        // lifetime. The Go side invokes fetchJSON() on every LoadPolicy
-        // call so the returned snapshot is always fresh — no caching here.
-        Android.setMobilePolicyFetcher(new MDMPolicyFetcher(this));
+        // NOTE: the MDM policy fetcher is registered on the goClient
+        // instance inside EngineRunner — see EngineRunner constructor.
+        // Process-wide registration was removed when the Go side moved
+        // to per-Client DI for the Loader.
     }
 }

--- a/app/src/main/java/io/netbird/client/MyApplication.java
+++ b/app/src/main/java/io/netbird/client/MyApplication.java
@@ -5,6 +5,8 @@ import android.content.SharedPreferences;
 
 import androidx.appcompat.app.AppCompatDelegate;
 
+import io.netbird.gomobile.android.Android;
+
 public class MyApplication extends Application {
 
     @Override
@@ -14,5 +16,10 @@ public class MyApplication extends Application {
         SharedPreferences prefs = getSharedPreferences("settings", MODE_PRIVATE);
         int themeMode = prefs.getInt("theme_mode", AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM);
         AppCompatDelegate.setDefaultNightMode(themeMode);
+
+        // Register the MDM policy fetcher exactly once for the process
+        // lifetime. The Go side invokes fetchJSON() on every LoadPolicy
+        // call so the returned snapshot is always fresh — no caching here.
+        Android.setMobilePolicyFetcher(new MDMPolicyFetcher(this));
     }
 }

--- a/app/src/main/java/io/netbird/client/ui/advanced/AdvancedFragment.java
+++ b/app/src/main/java/io/netbird/client/ui/advanced/AdvancedFragment.java
@@ -1,9 +1,13 @@
 package io.netbird.client.ui.advanced;
 
 import android.content.Context;
+import android.content.RestrictionsManager;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.util.Log;
+import android.widget.CompoundButton;
+import android.widget.EditText;
+import android.view.View;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -292,8 +296,76 @@ public class AdvancedFragment extends Fragment {
                 binding.switchDisableIpv6.toggle();
             });
 
+            applyMDMLocks();
+
         } catch (Exception e) {
             Log.e(LOGTAG, "Failed to initialize engine config switches", e);
+        }
+    }
+
+    /**
+     * Lock and align every UI control whose corresponding key is currently
+     * MDM-enforced. The list of managed keys + their enforced values is
+     * read directly from RestrictionsManager — the same OS-native source
+     * the Go layer uses (via MDMPolicyFetcher). No round-trip to Go is
+     * needed, and the two sides cannot diverge.
+     *
+     * For each managed key:
+     *   - the switch is forced to the MDM value (overrides the user's
+     *     on-disk preference);
+     *   - the switch + its surrounding clickable layout are disabled so
+     *     the user cannot toggle them.
+     */
+    private void applyMDMLocks() {
+        Context ctx = getContext();
+        if (ctx == null) {
+            return;
+        }
+        RestrictionsManager rm = (RestrictionsManager) ctx.getSystemService(Context.RESTRICTIONS_SERVICE);
+        if (rm == null) {
+            return;
+        }
+        android.os.Bundle restrictions = rm.getApplicationRestrictions();
+        if (restrictions == null || restrictions.isEmpty()) {
+            return;
+        }
+
+        lockSwitchIfManaged(restrictions, "rosenpassEnabled", binding.switchRosenpass, binding.layoutRosenpas);
+        lockSwitchIfManaged(restrictions, "rosenpassPermissive", binding.switchRosenpassPermissive, binding.layoutRosenpassPermissive);
+        lockSwitchIfManaged(restrictions, "allowServerSSH", binding.switchAllowSsh, binding.layoutAllowSsh);
+        lockSwitchIfManaged(restrictions, "blockInbound", binding.switchBlockInbound, binding.layoutBlockInbound);
+        lockSwitchIfManaged(restrictions, "disableClientRoutes", binding.switchDisableClientRoutes, binding.layoutDisableClientRoutes);
+        lockSwitchIfManaged(restrictions, "disableServerRoutes", binding.switchDisableServerRoutes, binding.layoutDisableServerRoutes);
+
+        // PreSharedKey is a string, not a bool; lock the field if managed.
+        if (restrictions.containsKey("preSharedKey")) {
+            EditText psk = binding.presharedKey;
+            psk.setEnabled(false);
+            // Show the redaction sentinel so the actual MDM value is never
+            // leaked into the UI — matches the daemon-side behavior of
+            // GetConfig.
+            psk.setText(hiddenKey);
+            binding.btnSave.setEnabled(false);
+        }
+    }
+
+    /**
+     * Helper: if `key` is present in the OS-pushed restrictions, force the
+     * switch to its enforced bool value and disable the switch and its
+     * parent layout. The parent layout must be disabled too, otherwise
+     * the TV-remote "tap layout to toggle switch" path remains active.
+     */
+    private void lockSwitchIfManaged(android.os.Bundle restrictions, String key,
+                                     CompoundButton switchCtrl, View parentLayout) {
+        if (switchCtrl == null || !restrictions.containsKey(key)) {
+            return;
+        }
+        boolean value = restrictions.getBoolean(key);
+        switchCtrl.setChecked(value);
+        switchCtrl.setEnabled(false);
+        if (parentLayout != null) {
+            parentLayout.setEnabled(false);
+            parentLayout.setClickable(false);
         }
     }
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Display labels for the splitTunnelMode managed restriction. -->
+    <string-array name="restriction_splitTunnelMode_entries">
+        <item>Allow only listed apps (everything else bypasses)</item>
+        <item>Disallow listed apps (everything else routes)</item>
+    </string-array>
+    <!-- Raw values written into RestrictionsManager for splitTunnelMode. -->
+    <string-array name="restriction_splitTunnelMode_values">
+        <item>allow</item>
+        <item>disallow</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,4 +148,58 @@
     <string name="profiles_success_switched">Switched to profile \'%s\'</string>
     <string name="profiles_success_logged_out">Logged out from profile \'%s\'</string>
     <string name="profiles_success_removed">Profile \'%s\' removed successfully</string>
+
+    <!-- MDM application restrictions: titles + descriptions surfaced to the
+         Device Owner / Profile Owner UI (Intune, MobileIron, TestDPC) when
+         the admin configures NetBird via managed config. -->
+    <string name="restriction_managementURL_title">Management URL</string>
+    <string name="restriction_managementURL_description">URL of the NetBird management server. Format https://host[:port].</string>
+
+    <string name="restriction_preSharedKey_title">Pre-shared key</string>
+    <string name="restriction_preSharedKey_description">WireGuard pre-shared key used as an additional symmetric secret. Secret value.</string>
+
+    <string name="restriction_disableAutoConnect_title">Disable auto-connect</string>
+    <string name="restriction_disableAutoConnect_description">When enabled, the tunnel does not auto-connect at app start.</string>
+
+    <string name="restriction_disableClientRoutes_title">Disable client routes</string>
+    <string name="restriction_disableClientRoutes_description">When enabled, this client does not consume routes advertised by routing peers.</string>
+
+    <string name="restriction_disableServerRoutes_title">Disable server routes</string>
+    <string name="restriction_disableServerRoutes_description">When enabled, this client does not act as a routing peer for other clients.</string>
+
+    <string name="restriction_blockInbound_title">Block inbound</string>
+    <string name="restriction_blockInbound_description">When enabled, the client blocks all inbound peer traffic on the WireGuard interface.</string>
+
+    <string name="restriction_allowServerSSH_title">Allow server SSH</string>
+    <string name="restriction_allowServerSSH_description">When enabled, this client accepts incoming SSH sessions via NetBird SSH.</string>
+
+    <string name="restriction_rosenpassEnabled_title">Enable Rosenpass</string>
+    <string name="restriction_rosenpassEnabled_description">Enables Rosenpass post-quantum key exchange on WireGuard tunnels.</string>
+
+    <string name="restriction_rosenpassPermissive_title">Rosenpass permissive</string>
+    <string name="restriction_rosenpassPermissive_description">When enabled, falls back to plain WireGuard if a peer does not support Rosenpass.</string>
+
+    <string name="restriction_wireguardPort_title">WireGuard port</string>
+    <string name="restriction_wireguardPort_description">UDP port for the local WireGuard interface. Allowed range 1-65535.</string>
+
+    <string name="restriction_splitTunnelMode_title">Split tunnel mode</string>
+    <string name="restriction_splitTunnelMode_description">Choose allow (only listed apps route through NetBird) or disallow (listed apps bypass NetBird).</string>
+
+    <string name="restriction_splitTunnelApps_title">Split tunnel apps</string>
+    <string name="restriction_splitTunnelApps_description">Comma-separated list of package names used by the selected split-tunnel mode.</string>
+
+    <string name="restriction_disableUpdateSettings_title">Disable update settings</string>
+    <string name="restriction_disableUpdateSettings_description">When enabled, blocks every configuration change from the UI and CLI.</string>
+
+    <string name="restriction_disableProfiles_title">Disable profiles</string>
+    <string name="restriction_disableProfiles_description">When enabled, the client cannot list, create, switch or remove NetBird connection profiles.</string>
+
+    <string name="restriction_disableNetworks_title">Disable networks</string>
+    <string name="restriction_disableNetworks_description">When enabled, the client UI cannot list, select or deselect NetBird networks.</string>
+
+    <string name="restriction_disableAdvancedView_title">Disable advanced view</string>
+    <string name="restriction_disableAdvancedView_description">When enabled, the new UI hides the advanced-view section.</string>
+
+    <string name="restriction_disableMetricsCollection_title">Disable metrics collection</string>
+    <string name="restriction_disableMetricsCollection_description">When enabled, the client does not collect or report local usage metrics.</string>
 </resources>

--- a/app/src/main/res/xml/app_restrictions.xml
+++ b/app/src/main/res/xml/app_restrictions.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Managed-configuration schema for the NetBird Android client.
+    Read by Device Owner / Profile Owner (Intune, MobileIron, Workspace ONE,
+    JumpCloud, TestDPC) to render a configuration UI; pushed values land in
+    RestrictionsManager.getApplicationRestrictions() and are surfaced to the
+    Go layer via MDMPolicyFetcher.fetchJSON().
+
+    Key names mirror the canonical mdm.Key* constants in
+    client/mdm/policy.go (lowerCamelCase). Adding a key here is purely
+    discovery for the MDM admin UI — the Go side determines which keys
+    actually take effect.
+-->
+<restrictions xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <restriction
+        android:key="managementURL"
+        android:title="@string/restriction_managementURL_title"
+        android:description="@string/restriction_managementURL_description"
+        android:restrictionType="string"
+        android:defaultValue="https://api.netbird.io:443" />
+
+    <restriction
+        android:key="preSharedKey"
+        android:title="@string/restriction_preSharedKey_title"
+        android:description="@string/restriction_preSharedKey_description"
+        android:restrictionType="string" />
+
+    <restriction
+        android:key="disableAutoConnect"
+        android:title="@string/restriction_disableAutoConnect_title"
+        android:description="@string/restriction_disableAutoConnect_description"
+        android:restrictionType="bool"
+        android:defaultValue="false" />
+
+    <restriction
+        android:key="disableClientRoutes"
+        android:title="@string/restriction_disableClientRoutes_title"
+        android:description="@string/restriction_disableClientRoutes_description"
+        android:restrictionType="bool"
+        android:defaultValue="false" />
+
+    <restriction
+        android:key="disableServerRoutes"
+        android:title="@string/restriction_disableServerRoutes_title"
+        android:description="@string/restriction_disableServerRoutes_description"
+        android:restrictionType="bool"
+        android:defaultValue="false" />
+
+    <restriction
+        android:key="blockInbound"
+        android:title="@string/restriction_blockInbound_title"
+        android:description="@string/restriction_blockInbound_description"
+        android:restrictionType="bool"
+        android:defaultValue="false" />
+
+    <restriction
+        android:key="allowServerSSH"
+        android:title="@string/restriction_allowServerSSH_title"
+        android:description="@string/restriction_allowServerSSH_description"
+        android:restrictionType="bool"
+        android:defaultValue="false" />
+
+    <restriction
+        android:key="rosenpassEnabled"
+        android:title="@string/restriction_rosenpassEnabled_title"
+        android:description="@string/restriction_rosenpassEnabled_description"
+        android:restrictionType="bool"
+        android:defaultValue="false" />
+
+    <restriction
+        android:key="rosenpassPermissive"
+        android:title="@string/restriction_rosenpassPermissive_title"
+        android:description="@string/restriction_rosenpassPermissive_description"
+        android:restrictionType="bool"
+        android:defaultValue="false" />
+
+    <restriction
+        android:key="wireguardPort"
+        android:title="@string/restriction_wireguardPort_title"
+        android:description="@string/restriction_wireguardPort_description"
+        android:restrictionType="integer"
+        android:defaultValue="51820" />
+
+    <restriction
+        android:key="splitTunnelMode"
+        android:title="@string/restriction_splitTunnelMode_title"
+        android:description="@string/restriction_splitTunnelMode_description"
+        android:restrictionType="choice"
+        android:entries="@array/restriction_splitTunnelMode_entries"
+        android:entryValues="@array/restriction_splitTunnelMode_values"
+        android:defaultValue="allow" />
+
+    <restriction
+        android:key="splitTunnelApps"
+        android:title="@string/restriction_splitTunnelApps_title"
+        android:description="@string/restriction_splitTunnelApps_description"
+        android:restrictionType="string" />
+
+    <restriction
+        android:key="disableUpdateSettings"
+        android:title="@string/restriction_disableUpdateSettings_title"
+        android:description="@string/restriction_disableUpdateSettings_description"
+        android:restrictionType="bool"
+        android:defaultValue="false" />
+
+    <restriction
+        android:key="disableProfiles"
+        android:title="@string/restriction_disableProfiles_title"
+        android:description="@string/restriction_disableProfiles_description"
+        android:restrictionType="bool"
+        android:defaultValue="false" />
+
+    <restriction
+        android:key="disableNetworks"
+        android:title="@string/restriction_disableNetworks_title"
+        android:description="@string/restriction_disableNetworks_description"
+        android:restrictionType="bool"
+        android:defaultValue="false" />
+
+    <restriction
+        android:key="disableAdvancedView"
+        android:title="@string/restriction_disableAdvancedView_title"
+        android:description="@string/restriction_disableAdvancedView_description"
+        android:restrictionType="bool"
+        android:defaultValue="false" />
+
+    <restriction
+        android:key="disableMetricsCollection"
+        android:title="@string/restriction_disableMetricsCollection_title"
+        android:description="@string/restriction_disableMetricsCollection_description"
+        android:restrictionType="bool"
+        android:defaultValue="false" />
+
+</restrictions>

--- a/tool/src/main/java/io/netbird/client/tool/EngineRestarter.java
+++ b/tool/src/main/java/io/netbird/client/tool/EngineRestarter.java
@@ -309,6 +309,22 @@ class EngineRestarter implements NetworkToggleListener {
     }
 
     /**
+     * Triggers the same stop + restart sequence used by the network-change
+     * path, but without the debounce delay. Used by the MDM policy-change
+     * broadcast receiver: when an admin pushes a new managed config the
+     * engine must restart immediately so the new values take effect on the
+     * next Run (which re-reads MDM via MDMPolicyFetcher).
+     */
+    public void requestRestartNow() {
+        Log.d(LOGTAG, "explicit restart requested (no debounce)");
+        synchronized (restartLock) {
+            restartScheduled = true;
+            handler.removeCallbacks(restartRunnable);
+            handler.post(restartRunnable);
+        }
+    }
+
+    /**
      * Cancels any pending debounced restart. Called whenever an external
      * actor (typically a user-driven Connect/Disconnect) takes over the
      * engine lifecycle, so the network-change-driven restart does not

--- a/tool/src/main/java/io/netbird/client/tool/EngineRunner.java
+++ b/tool/src/main/java/io/netbird/client/tool/EngineRunner.java
@@ -245,6 +245,18 @@ class EngineRunner {
         goClient.stop();
     }
 
+    /**
+     * Invoked by the platform broadcast receiver when the OS reports a
+     * managed-config change (Intent.ACTION_APPLICATION_RESTRICTIONS_CHANGED).
+     * Delegates to the Go layer; on the Go side this stops the current
+     * engine context so the outer loop (runClient) wakes up and re-invokes
+     * Run with a freshly resolved Config that includes the latest MDM
+     * overlay.
+     */
+    public synchronized void onMDMPolicyChanged() {
+        goClient.onMDMPolicyChanged();
+    }
+
     public PeerInfoArray peersInfo() {
         return goClient.peersList();
     }

--- a/tool/src/main/java/io/netbird/client/tool/EngineRunner.java
+++ b/tool/src/main/java/io/netbird/client/tool/EngineRunner.java
@@ -48,6 +48,12 @@ class EngineRunner {
                 iFaceDiscover,
                 networkChangeListener);
 
+        // Per-Client MDM policy fetcher (DI on the goClient side).
+        // The Go layer holds the *mdm.Loader on this Client instance;
+        // every Run/RunWithoutLogin call overlays the latest MDM
+        // policy on top of the freshly resolved Config.
+        goClient.setMDMPolicyFetcher(new MDMPolicyFetcher(context));
+
         updateLogLevel(isTraceLogEnabled, isDebuggable);
     }
 

--- a/tool/src/main/java/io/netbird/client/tool/EngineRunner.java
+++ b/tool/src/main/java/io/netbird/client/tool/EngineRunner.java
@@ -245,18 +245,6 @@ class EngineRunner {
         goClient.stop();
     }
 
-    /**
-     * Invoked by the platform broadcast receiver when the OS reports a
-     * managed-config change (Intent.ACTION_APPLICATION_RESTRICTIONS_CHANGED).
-     * Delegates to the Go layer; on the Go side this stops the current
-     * engine context so the outer loop (runClient) wakes up and re-invokes
-     * Run with a freshly resolved Config that includes the latest MDM
-     * overlay.
-     */
-    public synchronized void onMDMPolicyChanged() {
-        goClient.onMDMPolicyChanged();
-    }
-
     public PeerInfoArray peersInfo() {
         return goClient.peersList();
     }

--- a/tool/src/main/java/io/netbird/client/tool/MDMPolicyFetcher.java
+++ b/tool/src/main/java/io/netbird/client/tool/MDMPolicyFetcher.java
@@ -1,4 +1,4 @@
-package io.netbird.client;
+package io.netbird.client.tool;
 
 import android.content.Context;
 import android.content.RestrictionsManager;
@@ -12,14 +12,17 @@ import org.json.JSONObject;
 import io.netbird.gomobile.android.PolicyFetcher;
 
 /**
- * MDMPolicyFetcher reads the current Android managed-config snapshot from
- * RestrictionsManager and returns it as a JSON-encoded string to the Go
- * layer. Registered once at app start via Android.setMobilePolicyFetcher;
- * the Go side invokes fetchJSON() on every LoadPolicy call so the response
- * is always fresh.
+ * MDMPolicyFetcher reads the current Android managed-config snapshot
+ * from RestrictionsManager and returns it as a JSON-encoded string to
+ * the Go layer. Registered on the goClient via setMDMPolicyFetcher
+ * inside EngineRunner; the Go side invokes fetchJSON() on every
+ * Loader.Load call so the response is always fresh.
  *
- * Returns an empty string when no managed config is set — the daemon side
- * treats that as the "no MDM source present" sentinel.
+ * Returns an empty string when no managed config is set — the daemon
+ * side treats that as the "no MDM source present" sentinel.
+ *
+ * Lives in the tool package so the network-extension target can
+ * instantiate it without depending on the app package.
  */
 public class MDMPolicyFetcher implements PolicyFetcher {
     private static final String TAG = "MDMPolicyFetcher";

--- a/tool/src/main/java/io/netbird/client/tool/VPNService.java
+++ b/tool/src/main/java/io/netbird/client/tool/VPNService.java
@@ -39,6 +39,7 @@ public class VPNService extends android.net.VpnService {
     private ConcreteNetworkAvailabilityListener networkAvailabilityListener;
     private EngineRestarter engineRestarter;
     private android.content.BroadcastReceiver stopEngineReceiver;
+    private android.content.BroadcastReceiver mdmPolicyChangedReceiver;
 
     @Override
     public void onCreate() {
@@ -99,6 +100,32 @@ public class VPNService extends android.net.VpnService {
                 filter,
                 Context.RECEIVER_NOT_EXPORTED
         );
+
+        // Listen for MDM managed-config changes. The OS broadcasts this
+        // intent whenever a Device Owner / Profile Owner pushes new
+        // application restrictions; the receiver only signals the engine
+        // to restart with a freshly resolved Config — the actual values
+        // are read on demand by MDMPolicyFetcher.fetchJSON during the
+        // next Run.
+        mdmPolicyChangedReceiver = new android.content.BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                if (Intent.ACTION_APPLICATION_RESTRICTIONS_CHANGED.equals(intent.getAction())) {
+                    Log.d(LOGTAG, "Received MDM policy change broadcast");
+                    if (engineRunner != null) {
+                        engineRunner.onMDMPolicyChanged();
+                    }
+                }
+            }
+        };
+        android.content.IntentFilter mdmFilter = new android.content.IntentFilter(
+                Intent.ACTION_APPLICATION_RESTRICTIONS_CHANGED);
+        androidx.core.content.ContextCompat.registerReceiver(
+                this,
+                mdmPolicyChangedReceiver,
+                mdmFilter,
+                Context.RECEIVER_NOT_EXPORTED
+        );
     }
 
     @Override
@@ -145,6 +172,13 @@ public class VPNService extends android.net.VpnService {
                 unregisterReceiver(stopEngineReceiver);
             } catch (IllegalArgumentException e) {
                 Log.w(LOGTAG, "Receiver not registered", e);
+            }
+        }
+        if (mdmPolicyChangedReceiver != null) {
+            try {
+                unregisterReceiver(mdmPolicyChangedReceiver);
+            } catch (IllegalArgumentException e) {
+                Log.w(LOGTAG, "MDM receiver not registered", e);
             }
         }
 

--- a/tool/src/main/java/io/netbird/client/tool/VPNService.java
+++ b/tool/src/main/java/io/netbird/client/tool/VPNService.java
@@ -112,8 +112,13 @@ public class VPNService extends android.net.VpnService {
             public void onReceive(Context context, Intent intent) {
                 if (Intent.ACTION_APPLICATION_RESTRICTIONS_CHANGED.equals(intent.getAction())) {
                     Log.d(LOGTAG, "Received MDM policy change broadcast");
-                    if (engineRunner != null) {
-                        engineRunner.onMDMPolicyChanged();
+                    // Route through EngineRestarter so the existing restart
+                    // machinery (state-listener gating, UI suppression
+                    // window, runWithoutAuth on stop) handles the stop +
+                    // re-run cleanly. A bare engineRunner.stop() leaves the
+                    // engine stopped with no one to relaunch it.
+                    if (engineRestarter != null) {
+                        engineRestarter.requestRestartNow();
                     }
                 }
             }


### PR DESCRIPTION
Adds Android MDM integration

```
[1] OS broadcast Intent.ACTION_APPLICATION_RESTRICTIONS_CHANGED
        │
        ▼
[2] VPNService.mdmPolicyChangedReceiver.onReceive()         tool/VPNService.java
        │
        ▼
[3] engineRestarter.requestRestartNow()                     tool/EngineRestarter.java:requestRestartNow
        ├─ restartScheduled = true
        └─ handler.post(restartRunnable)                    [immediate, no debounce]
        │
        ▼
[4] EngineRestarter.restartEngine()                         (private, run on UI thread by handler)
        ├─ check engineRunner.isRunning() → true
        ├─ wrap connection listener in FilteringConnectionListener
        │     [filtra eventi disconnect del teardown del vecchio engine]
        ├─ engineRunner.addServiceStateListenerForRestart(serviceStateListener)
        ├─ engineRunner.snapshotExternalListeners() + suppressServiceStateListener(...)
        │     [blocks other listeners during restart window]
        ├─ notifyConnecting(savedListener)                  [UI: orange circle in progress]
        └─ engineRunner.stop()                              tool/EngineRunner.java:stop
            │
            ▼
[5] goClient.stop() (gomobile JNI)                          → Go Client.Stop() → ctx cancel
[6] Go-side Run() in EngineRunner thread rientra dal blocking call
        ├─ catch/finally: engineIsRunning = false
        └─ notifyServiceStateListeners(false)               → fire onStopped on all listeners
        │
        ▼
[7] serviceStateListener.onStopped() (registered in step 4)
        └─ engineRunner.runWithoutAuth()                    tool/EngineRunner.java:runWithoutAuth
            │
            ▼
[8] runClient(null, false) — new spawned thread
        ├─ profileManager.getActiveConfigPath() / getActiveStateFilePath()
        ├─ new AndroidPlatformFiles(...)
        ├─ notifyServiceStateListeners(true) → fire onStarted
        └─ goClient.runWithoutLogin(...)                    (gomobile JNI)
            │
            ▼
[9] Go-side: UpdateOrCreateConfig → Config.apply → applyMDMPolicy(loadMDMPolicy())
        ├─ loadMDMPolicy → LoadPolicy → loadPlatformPolicy
        │     → fetcher.Fetch() → JSON adapter → kotlinFetcher.FetchJSON()
        │     → MDMPolicyFetcher.fetchJSON() (JNI back)     app/.../MDMPolicyFetcher.java
        │         → RestrictionsManager.getApplicationRestrictions()
        │         → Bundle → JSON
        ├─ MDM overlay applied to Config
        └─ NewConnectClient(ctx, freshCfg) → engine start
        │
        ▼
[10] serviceStateListener.onStarted()                       tool/EngineRestarter.java:115
        ├─ isRestartInProgress = false
        ├─ engineRunner.setConnectionListener(savedListener)   [remove FilteringConnectionListener]
        └─ unsuppressAll(suppressed)                        [re-enable external listener]
        │
        ▼
[11] Engine raggiunge stato CONNECTED
        └─ ConnectionListener.onConnected() (non più filtrato)
            → UI: cerchio colorato + "Connected"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Android managed-config (MDM) to deliver enforced settings into the app.
  * Managed settings are now reflected in the UI as locked/read-only, including split-tunnel mode and related options.
  * When device policies change, the app now triggers an immediate restart to apply updates, and the engine receives the latest managed policy overlay.
  * Added a managed-config schema and localized descriptions for the enforced fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->