### PR TITLE
Use Build.MODEL for device hostname instead of Build.PRODUCT

### DIFF
--- a/app/src/main/java/io/netbird/client/ui/server/ChangeServerFragment.java
+++ b/app/src/main/java/io/netbird/client/ui/server/ChangeServerFragment.java
@@ -258,7 +258,7 @@ public class ChangeServerFragment extends Fragment {
     }
 
     private String deviceName() {
-        return Build.PRODUCT;
+        return Build.MODEL;
     }
 
     private void disableUIElements() {


### PR DESCRIPTION
## Summary

The Android client uses `deviceName()` in `ChangeServerFragment` as the peer hostname reported to the NetBird management server (flows through `LoginWithSetupKeyAndSaveConfig` → `system.DeviceNameCtxKey` → `Info.Hostname`).

It previously returned `Build.PRODUCT`, which is the internal AOSP build product name (e.g. `raven`, `sdk_gphone64_arm64`) — not human-readable.

This changes it to `Build.MODEL`, the user-facing model name (e.g. `Pixel 6`), giving a more recognizable peer hostname in the NetBird dashboard.

## Change

`app/src/main/java/io/netbird/client/ui/server/ChangeServerFragment.java`
```diff
 private String deviceName() {
-    return Build.PRODUCT;
+    return Build.MODEL;
 }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the device name shown when changing servers by using a more accurate device model identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->