### PR TITLE
Support user added CAs in android client

### DIFF
--- a/app/src/main/java/io/netbird/client/MyApplication.java
+++ b/app/src/main/java/io/netbird/client/MyApplication.java
@@ -1,15 +1,27 @@
 package io.netbird.client;
 
+import android.util.Log;
 import android.app.Application;
 import android.content.SharedPreferences;
 
 import androidx.appcompat.app.AppCompatDelegate;
+
+import io.netbird.gomobile.android.Android;
 
 public class MyApplication extends Application {
 
     @Override
     public void onCreate() {
         super.onCreate();
+
+	    try {
+            byte[] certsPem = PlatformUtils.getSystemAndUserCertificates();
+            Android.setAndroidCertificates(certsPem);
+            Log.d("NetBird-CA", "System and User certificates successfully passed to Go core.");
+        } catch (Exception e) {
+            Log.e("NetBird-CA", "Failed to extract or pass Android certificates to Go core", e);
+        }
+
         // Set Theme at start
         SharedPreferences prefs = getSharedPreferences("settings", MODE_PRIVATE);
         int themeMode = prefs.getInt("theme_mode", AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM);

--- a/app/src/main/java/io/netbird/client/PlatformUtils.java
+++ b/app/src/main/java/io/netbird/client/PlatformUtils.java
@@ -4,6 +4,13 @@ import android.app.UiModeManager;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
+import android.util.Base64;
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
+import java.util.Enumeration;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
 
 public final class PlatformUtils {
 
@@ -27,5 +34,33 @@ public final class PlatformUtils {
     public static boolean requiresDeviceCodeFlow(Context context) {
         return isAndroidTV(context) || isChromeOS(context);
     }
-}
 
+    public static byte[] getSystemAndUserCertificates() throws Exception {
+        KeyStore keyStore = KeyStore.getInstance("AndroidCAStore");
+        keyStore.load(null, null);
+
+        StringBuilder pemBuilder = new StringBuilder();
+        Enumeration<String> aliases = keyStore.aliases();
+
+        while (aliases.hasMoreElements()) {
+            String alias = aliases.nextElement();
+            if (!alias.startsWith("user:")) {
+                continue;
+            }
+
+            X509Certificate cert = (X509Certificate) keyStore.getCertificate(alias);
+            if (cert != null) {
+                String base64Cert = Base64.encodeToString(cert.getEncoded(), Base64.NO_WRAP);
+                
+                pemBuilder.append("-----BEGIN CERTIFICATE-----\n");
+                for (int i = 0; i < base64Cert.length(); i += 64) {
+                    int end = Math.min(i + 64, base64Cert.length());
+                    pemBuilder.append(base64Cert.substring(i, end)).append("\n");
+                }
+                pemBuilder.append("-----END CERTIFICATE-----\n");
+            }
+        }
+
+        return pemBuilder.toString().getBytes("UTF-8");
+    }
+}


### PR DESCRIPTION
The android stores the Certificate Authorities separately which are installed by the user. The Golang ecosystem does not care about them by default, so there was no possibility to use them in self-hosted environment on android clients with user supplied CA. As my understanding to fix that the android code should collect the Certificates Authorities with java API, supply them to go code, and consume it combined with the system provided CAs.
By default the system CAs will be used in Golang.

* Bump netbird submodule to include updated golang code

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/android-client/pr/224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787840692&installation_model_id=427504&pr_number=224&repository=netbirdio%2Fandroid-client&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fandroid-client%2Fpull%2F224&signature=6ed1a62bf5e2deec0e43dd78af58d8392cc4aafec35714c7f75ae8c3f943f99d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic integration of Android system and user certificates with the secure network connection during app startup.
  * Certificates are extracted and converted to PEM, then supplied to the secure networking core before theme initialization.

* **Bug Fixes**
  * Added error handling and logging for certificate extraction and handoff failures.

* **Chores**
  * Updated the bundled networking core to a newer revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->