### PR TITLE
Pass an anonymization level to the debug bundle SDK call

### DIFF
--- a/tool/src/main/java/io/netbird/client/tool/EngineRunner.java
+++ b/tool/src/main/java/io/netbird/client/tool/EngineRunner.java
@@ -327,7 +327,9 @@ class EngineRunner {
         String cacheDir = context.getCacheDir().getAbsolutePath();
         var platformFiles = new AndroidPlatformFiles(configPath, statePath, cacheDir);
         try {
-            return goClient.debugBundle(platformFiles, anonymize);
+            // The strict level stays unused until the troubleshoot screen
+            // grows an option for it.
+            return goClient.debugBundle(platformFiles, anonymize, Android.AnonymizeLevelDefault);
         } catch (Exception e) {
             Log.e(LOGTAG, "goClient error", e);
             throw e;


### PR DESCRIPTION
Adapts the app to the debug bundle anonymization level introduced in netbirdio/netbird#7102 and bumps the netbird submodule to include it.

- Pass the SDK-exported default level constant to the debug bundle call in EngineRunner; behavior is unchanged and the Go bindings stay confined to the tool package
- Bump the netbird submodule to the netbirdio/netbird#7102 merge commit

A troubleshoot-screen option for the strict level can follow separately.
