### PR TITLE
Pin gobind alongside gomobile instead of running gomobile init

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -80,17 +80,46 @@ runs:
       shell: bash
       run: echo "ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/23.1.7779620" >> $GITHUB_ENV
 
-    - name: Cache gomobile binary
+    # gomobile bind shells out to gobind, and gobind is the tool that actually
+    # generates the Java bindings and the JNI glue. Caching and installing only
+    # gomobile left gobind to `gomobile init`, which pulls it from @latest: the
+    # driver was pinned while the generator floated, so the generated API could
+    # change without a commit here. Taking the revision from the go.mod the
+    # submodule already carries keeps the two from drifting apart, and lets the
+    # cache key follow a submodule bump on its own.
+    - name: Resolve the gomobile revision
+      id: gomobile-version
+      shell: bash
+      run: |
+        set -euo pipefail
+        version=$(cd netbird && go list -m -f '{{.Version}}' golang.org/x/mobile)
+        if [ -z "$version" ]; then
+          echo "::error::could not resolve the golang.org/x/mobile version from netbird/go.mod"
+          exit 1
+        fi
+        echo "Using gomobile and gobind at $version"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
+    # The key has to name both tools, not just the revision: entries saved by
+    # the earlier gomobile-only step hold no gobind, so reusing that key would
+    # hit the cache, skip the install and leave the build without a generator.
+    - name: Cache gomobile and gobind
       id: gomobile-cache
       uses: actions/cache@v4
       with:
-        path: ~/go/bin/gomobile
-        key: gomobile-v0.0.0-20251113184115-a159579294ab
+        path: |
+          ~/go/bin/gomobile
+          ~/go/bin/gobind
+        key: gomobile-gobind-${{ steps.gomobile-version.outputs.version }}
 
-    - name: Install gomobile
+    - name: Install gomobile and gobind
       if: steps.gomobile-cache.outputs.cache-hit != 'true'
       shell: bash
-      run: go install golang.org/x/mobile/cmd/gomobile@v0.0.0-20251113184115-a159579294ab
+      run: |
+        set -euo pipefail
+        version='${{ steps.gomobile-version.outputs.version }}'
+        go install "golang.org/x/mobile/cmd/gomobile@$version"
+        go install "golang.org/x/mobile/cmd/gobind@$version"
 
     - name: Build NetBird Go library
       shell: bash

--- a/build-android-lib.sh
+++ b/build-android-lib.sh
@@ -78,25 +78,38 @@ get_version() {
 # generates the Java bindings and the JNI glue. Its own suggestion for a missing
 # gobind is `gomobile init`, which installs it from @latest — that would let the
 # generator float even though the driver is pinned, changing the generated API
-# without a commit here. So both are installed up front at the revision go.mod
-# names, and this only checks that they are there.
+# without a commit here. So both tools are held to the revision go.mod names:
+# the module version embedded in each binary (go version -m) is compared to
+# that pin, and a missing or diverging tool is reinstalled at the pin.
 #
-# Must run inside the submodule: the version quoted below comes from its go.mod.
-check_gomobile_tools() {
-  local missing=""
-  command -v gomobile >/dev/null || missing="gomobile"
-  command -v gobind >/dev/null || missing="${missing:+$missing }gobind"
-  # Explicit 0: a bare return would propagate the test's exit status and set -e
-  # would abort the build on the success path.
-  [ -n "$missing" ] || return 0
+# GOBIN is prepended to PATH so the binary this function verified or installed
+# is the one `gomobile bind` (and its PATH lookup of gobind) actually runs,
+# even when another copy sits earlier on the caller's PATH.
+#
+# Must run inside the submodule: the pinned version comes from its go.mod.
+ensure_gomobile_tools() {
+  local want
+  want=$(go list -m -f '{{.Version}}' golang.org/x/mobile)
 
-  echo "ERROR: not on PATH: $missing" >&2
-  echo "Install both at the pinned revision, do not run 'gomobile init':" >&2
-  local version
-  version=$(go list -m -f '{{.Version}}' golang.org/x/mobile)
-  echo "  go install golang.org/x/mobile/cmd/gomobile@$version" >&2
-  echo "  go install golang.org/x/mobile/cmd/gobind@$version" >&2
-  exit 1
+  local gobin
+  gobin=$(go env GOBIN)
+  [ -n "$gobin" ] || gobin="$(go env GOPATH)/bin"
+  export PATH="$gobin:$PATH"
+
+  local tool path have
+  for tool in gomobile gobind; do
+    have=""
+    if path=$(command -v "$tool"); then
+      # `|| true`: go version fails on binaries without build info, and set -e
+      # would abort instead of letting the reinstall below repair the tool.
+      have=$(go version -m "$path" 2>/dev/null \
+        | awk '$1 == "mod" && $2 == "golang.org/x/mobile" {print $3}') || true
+    fi
+    if [ "$have" != "$want" ]; then
+      echo "Installing $tool at the go.mod pin $want (found: ${have:-none})"
+      go install "golang.org/x/mobile/cmd/$tool@$want"
+    fi
+  done
 }
 
 cd netbird
@@ -105,7 +118,7 @@ cd netbird
 version=$(get_version "${1:-}")
 echo "Using version: $version"
 
-check_gomobile_tools
+ensure_gomobile_tools
 
 CGO_ENABLED=0 gomobile bind \
   -o "$app_path/gomobile/netbird.aar" \

--- a/build-android-lib.sh
+++ b/build-android-lib.sh
@@ -74,13 +74,38 @@ get_version() {
   echo "ci-$short_hash"
 }
 
+# gomobile bind shells out to gobind, and gobind is the tool that actually
+# generates the Java bindings and the JNI glue. Its own suggestion for a missing
+# gobind is `gomobile init`, which installs it from @latest — that would let the
+# generator float even though the driver is pinned, changing the generated API
+# without a commit here. So both are installed up front at the revision go.mod
+# names, and this only checks that they are there.
+#
+# Must run inside the submodule: the version quoted below comes from its go.mod.
+check_gomobile_tools() {
+  local missing=""
+  command -v gomobile >/dev/null || missing="gomobile"
+  command -v gobind >/dev/null || missing="${missing:+$missing }gobind"
+  # Explicit 0: a bare return would propagate the test's exit status and set -e
+  # would abort the build on the success path.
+  [ -n "$missing" ] || return 0
+
+  echo "ERROR: not on PATH: $missing" >&2
+  echo "Install both at the pinned revision, do not run 'gomobile init':" >&2
+  local version
+  version=$(go list -m -f '{{.Version}}' golang.org/x/mobile)
+  echo "  go install golang.org/x/mobile/cmd/gomobile@$version" >&2
+  echo "  go install golang.org/x/mobile/cmd/gobind@$version" >&2
+  exit 1
+}
+
 cd netbird
 
 # Get version using the function
 version=$(get_version "${1:-}")
 echo "Using version: $version"
 
-gomobile init
+check_gomobile_tools
 
 CGO_ENABLED=0 gomobile bind \
   -o "$app_path/gomobile/netbird.aar" \


### PR DESCRIPTION
gomobile bind shells out to gobind, and gobind is the tool that actually generates the Java bindings and the JNI glue. CI cached and installed only gomobile and left the build script to call `gomobile init`, which installs gobind from @latest: the driver was pinned while the generator floated, so the generated API could change without a commit here.

Take the revision from the go.mod the submodule already carries, so the two tools cannot drift apart and the cache key follows a submodule bump on its own, and have the build script check that the pair is present rather than reaching for gomobile init.

The cache key names both tools now. Entries saved under the old key hold no gobind, so keeping it would hit the cache, skip the install and leave the build without a generator.

https://github.com/netbirdio/netbird/pull/7229