### PR TITLE
Support ad-hoc snapsot APK from CI

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -67,9 +67,46 @@ runs:
       shell: bash
       run: echo "ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/23.1.7779620" >> $GITHUB_ENV
 
-    - name: Install gomobile
+    # gomobile bind shells out to gobind, and gobind is the tool that actually
+    # generates the Java bindings and the JNI glue. Caching and installing only
+    # gomobile left gobind to `gomobile init`, which pulls it from @latest: the
+    # driver was pinned while the generator floated, so the generated API could
+    # change without a commit here. Taking the revision from the go.mod the
+    # submodule already carries keeps the two from drifting apart, and lets the
+    # cache key follow a submodule bump on its own.
+    - name: Resolve the gomobile revision
+      id: gomobile-version
       shell: bash
-      run: go install golang.org/x/mobile/cmd/gomobile@v0.0.0-20251113184115-a159579294ab
+      run: |
+        set -euo pipefail
+        version=$(cd netbird && go list -m -f '{{.Version}}' golang.org/x/mobile)
+        if [ -z "$version" ]; then
+          echo "::error::could not resolve the golang.org/x/mobile version from netbird/go.mod"
+          exit 1
+        fi
+        echo "Using gomobile and gobind at $version"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
+    # The key has to name both tools, not just the revision: entries saved by
+    # the earlier gomobile-only step hold no gobind, so reusing that key would
+    # hit the cache, skip the install and leave the build without a generator.
+    - name: Cache gomobile and gobind
+      id: gomobile-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/go/bin/gomobile
+          ~/go/bin/gobind
+        key: gomobile-gobind-${{ steps.gomobile-version.outputs.version }}
+
+    - name: Install gomobile and gobind
+      if: steps.gomobile-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        version='${{ steps.gomobile-version.outputs.version }}'
+        go install "golang.org/x/mobile/cmd/gomobile@$version"
+        go install "golang.org/x/mobile/cmd/gobind@$version"
 
     - name: Build NetBird Go library
       shell: bash

--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -60,8 +60,19 @@ runs:
       uses: actions/setup-go@v5
       with:
         go-version-file: "netbird/go.mod"
+        cache-dependency-path: "netbird/go.sum"
+
+    - name: Cache Android NDK
+      id: ndk-cache
+      uses: actions/cache@v4
+      with:
+        # ANDROID_HOME is set by the runner image but not visible to ${{ env.X }}
+        # in composite actions; the ubuntu-latest image pins it to this path.
+        path: /usr/local/lib/android/sdk/ndk/23.1.7779620
+        key: ndk-23.1.7779620
 
     - name: Setup NDK
+      if: steps.ndk-cache.outputs.cache-hit != 'true'
       shell: bash
       run: ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --install "ndk;23.1.7779620"
 

--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -32,11 +32,20 @@ runs:
         echo "Version Code: ${{ inputs.version_code }}"
         echo "Build Type: ${{ inputs.build_type }}"
 
-    - name: Fetch tags for submodule
+    - name: Fetch tags and history for submodule
       shell: bash
       run: |
         cd netbird
-        git fetch --tags
+        # build-android-lib.sh resolves the version by walking HEAD's ancestry
+        # back to the last release tag. actions/checkout clones submodules
+        # shallow, which fetches the tags but not the commits between HEAD and
+        # the tag, so without full history the walk comes up empty and the
+        # build silently falls back to a ci-<sha> version.
+        if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+          git fetch --unshallow --tags
+        else
+          git fetch --tags
+        fi
 
     - name: Setup Java
       uses: actions/setup-java@v4

--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -51,7 +51,9 @@ runs:
       uses: actions/setup-java@v4
       with:
         java-version: "17"
-        distribution: "adopt"
+        # AdoptOpenJDK became Eclipse Temurin; resolving "adopt" now fails
+        # outright, so the build never gets as far as installing a JDK.
+        distribution: "temurin"
         cache: "gradle"
 
     - name: Install Go

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -1,12 +1,10 @@
-name: build release
+name: build snapshot
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
 
 permissions:
-  contents: write
-  # Needed to read the run counts the version code is derived from.
+  contents: read
   actions: read
 
 concurrency:
@@ -14,36 +12,29 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build-release:
+  build-snapshot:
     runs-on: ubuntu-latest
     environment: android-release
     env:
       NETBIRD_UPLOAD_KEY_ALIAS: ${{ secrets.NETBIRD_UPLOAD_KEY_ALIAS }}
       NETBIRD_UPLOAD_KEY_PASSWORD: ${{ secrets.NETBIRD_UPLOAD_KEY_PASSWORD }}
       NETBIRD_UPLOAD_STORE_PASSWORD: ${{ secrets.NETBIRD_UPLOAD_STORE_PASSWORD }}
-    outputs:
-      apk_path: ${{ steps.build.outputs.apk_path }}
-      bundle_path: ${{ steps.build.outputs.bundle_path }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Get version
+      # Reaches the management server as the peer's ui_version and is shown on
+      # the app's about screen, so it has to say at a glance that this build was
+      # signed and handed out rather than released. build-debug.yml already
+      # claims the ci- prefix, and sharing it would make an unsigned PR build
+      # and a signed hand-out indistinguishable in the peer list.
+      - name: Get version name
         id: version
         run: |
-          TAG_NAME=${{ github.event.release.tag_name }}
-          echo "version_name=$TAG_NAME" >> $GITHUB_OUTPUT
-
-      - name: Write google-services.json
-        run: |
-          echo "${{ secrets.GOOGLE_JSON }}" | base64 -d > app/google-services.json
-
-      - name: Write keystore file
-        run: |
-          echo "${{ secrets.GPLAY_KEYSTORE }}" | base64 -d > gplay.keystore
-          echo "NETBIRD_UPLOAD_STORE_FILE=$GITHUB_WORKSPACE/gplay.keystore" >> $GITHUB_ENV
+          SHORT_GIT_SHA=$(git rev-parse --short HEAD)
+          echo "version_name=snapshot-${SHORT_GIT_SHA}" >> "$GITHUB_OUTPUT"
 
       # Must stay identical to the Compute version code step in the sibling
       # workflow. build-release.yml and build-snapshot.yml feed the same Play
@@ -82,6 +73,15 @@ jobs:
           echo "Release runs: $release_runs, snapshot runs: $snapshot_runs -> version_code=$version_code"
           echo "version_code=$version_code" >> "$GITHUB_OUTPUT"
 
+      - name: Write google-services.json
+        run: |
+          echo "${{ secrets.GOOGLE_JSON }}" | base64 -d > app/google-services.json
+
+      - name: Write keystore file
+        run: |
+          echo "${{ secrets.GPLAY_KEYSTORE }}" | base64 -d > gplay.keystore
+          echo "NETBIRD_UPLOAD_STORE_FILE=$GITHUB_WORKSPACE/gplay.keystore" >> "$GITHUB_ENV"
+
       - name: Build Android
         id: build
         uses: ./.github/actions/build-android
@@ -90,10 +90,11 @@ jobs:
           version_code: ${{ steps.version_code.outputs.version_code }}
           build_type: release
 
-      - name: Upload files to existing release
-        uses: softprops/action-gh-release@v1
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
         with:
-          files: |
+          name: ${{ steps.version.outputs.version_name }}
+          path: |
             ${{ steps.build.outputs.apk_path }}
             ${{ steps.build.outputs.bundle_path }}
-          tag_name: ${{ github.event.release.tag_name }}
+          retention-days: 14

--- a/build-android-lib.sh
+++ b/build-android-lib.sh
@@ -1,15 +1,27 @@
 #!/bin/bash
 # Script to build NetBird mobile bindings using gomobile
 # Usage: ./script.sh [version]
-# - If a version is provided, it will be used (with leading 'v' stripped if present).
-# - If no version is provided:
-#     * Uses the latest Git tag if available (with leading 'v' stripped if present).
-#     * Otherwise, defaults to "dev-<short-hash>".
-# - When running in GitHub Actions, uses "ci-<short-hash>" instead of "dev-<short-hash>".
+#
+# Version resolution (first match wins):
+#   1. explicit argument            -> the argument ('v' prefix stripped)
+#   2. local build (any HEAD)       -> dev-<sha>
+#   3. CI, HEAD on a release tag    -> that tag, e.g. 0.77.0
+#   4. CI, commits on top of a tag  -> 0.77.0+<sha>
+#   5. CI, no reachable tag         -> ci-<sha>
+#
+# The base tag is the last stable release tag (vX.Y.Z, no pre-release) found
+# walking back HEAD's ancestry in the netbird submodule — the last tag on this
+# branch, not the newest tag in the repository. <sha> is the submodule commit.
 
 set -euo pipefail
 
 app_path=$(pwd)
+
+# Stable release tags only ("v" + digits, no pre-release suffix): a pre-release
+# base such as "0.75.0-rc.2" would land in SemVer pre-release position, which
+# the management server compares differently from a plain release.
+readonly RELEASE_TAG_MATCH='v[0-9]*'
+readonly RELEASE_TAG_EXCLUDE='*-*'
 
 # Normalize semantic versions to drop a leading 'v' (e.g., v1.2.3 -> 1.2.3).
 # Only strips if the string starts with 'v' followed by a digit, so it won't affect
@@ -22,33 +34,44 @@ normalize_version() {
   echo "$ver"
 }
 
+describe_release_tag() {
+  git describe --tags "$@" --match "$RELEASE_TAG_MATCH" --exclude "$RELEASE_TAG_EXCLUDE" 2>/dev/null || true
+}
+
 get_version() {
   if [ -n "${1:-}" ]; then
     normalize_version "$1"
     return
   fi
 
-  # Try to get an exact tag
-  local tag
-  tag=$(git describe --tags --exact-match 2>/dev/null || true)
+  local short_hash
+  short_hash=$(git rev-parse --short HEAD)
 
+  if [ "${GITHUB_ACTIONS:-}" != "true" ]; then
+    echo "dev-$short_hash"
+    return
+  fi
+
+  local tag
+  tag=$(describe_release_tag --exact-match)
   if [ -n "$tag" ]; then
     normalize_version "$tag"
     return
   fi
 
-  # Fallback to "<prefix>-<short-hash>"
-  local short_hash
-  short_hash=$(git rev-parse --short HEAD)
-
-  local new_version
-  if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
-    new_version="ci-$short_hash"
-  else
-    new_version="dev-$short_hash"
+  # Walks HEAD's ancestry, so this is the last release tag on this branch,
+  # not the most recently created tag in the repository.
+  tag=$(describe_release_tag --abbrev=0)
+  if [ -n "$tag" ]; then
+    echo "$(normalize_version "$tag")+$short_hash"
+    return
   fi
 
-  echo "$new_version"
+  echo "WARNING: no release tag reachable from HEAD; using ci-$short_hash" >&2
+  if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+    echo "WARNING: the submodule is a shallow clone; the tag lookup needs full history" >&2
+  fi
+  echo "ci-$short_hash"
 }
 
 cd netbird

--- a/build-android-lib.sh
+++ b/build-android-lib.sh
@@ -74,13 +74,51 @@ get_version() {
   echo "ci-$short_hash"
 }
 
+# gomobile bind shells out to gobind, and gobind is the tool that actually
+# generates the Java bindings and the JNI glue. Its own suggestion for a missing
+# gobind is `gomobile init`, which installs it from @latest — that would let the
+# generator float even though the driver is pinned, changing the generated API
+# without a commit here. So both tools are held to the revision go.mod names:
+# the module version embedded in each binary (go version -m) is compared to
+# that pin, and a missing or diverging tool is reinstalled at the pin.
+#
+# GOBIN is prepended to PATH so the binary this function verified or installed
+# is the one `gomobile bind` (and its PATH lookup of gobind) actually runs,
+# even when another copy sits earlier on the caller's PATH.
+#
+# Must run inside the submodule: the pinned version comes from its go.mod.
+ensure_gomobile_tools() {
+  local want
+  want=$(go list -m -f '{{.Version}}' golang.org/x/mobile)
+
+  local gobin
+  gobin=$(go env GOBIN)
+  [ -n "$gobin" ] || gobin="$(go env GOPATH)/bin"
+  export PATH="$gobin:$PATH"
+
+  local tool path have
+  for tool in gomobile gobind; do
+    have=""
+    if path=$(command -v "$tool"); then
+      # `|| true`: go version fails on binaries without build info, and set -e
+      # would abort instead of letting the reinstall below repair the tool.
+      have=$(go version -m "$path" 2>/dev/null \
+        | awk '$1 == "mod" && $2 == "golang.org/x/mobile" {print $3}') || true
+    fi
+    if [ "$have" != "$want" ]; then
+      echo "Installing $tool at the go.mod pin $want (found: ${have:-none})"
+      go install "golang.org/x/mobile/cmd/$tool@$want"
+    fi
+  done
+}
+
 cd netbird
 
 # Get version using the function
 version=$(get_version "${1:-}")
 echo "Using version: $version"
 
-gomobile init
+ensure_gomobile_tools
 
 CGO_ENABLED=0 gomobile bind \
   -o "$app_path/gomobile/netbird.aar" \

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,52 @@
+# Android client build and versioning
+
+## The three workflows
+
+### `build-debug.yml` — the CI gate
+
+Runs automatically on every pull request and on every push to `main`. It has
+three jobs: `build-debug` produces the AAR and a debug APK/AAB, then
+`unit-tests` and `instrumented-tests` download that AAR and run against it, the
+latter on an emulator.
+
+Its product is a pass/fail signal, plus the `netbird-aar` artifact that the two
+test jobs consume. The debug APK it uploads is a convenience for humans; nothing
+in CI reads it.
+
+### `build-release.yml` — the published release
+
+Triggered by `release: published`, which fires for pre-releases too. It builds
+the signed APK and AAB and attaches them to the GitHub release. This is the
+source of anything that goes to the Play Store.
+
+Release candidates run through this workflow: they are ordinary GitHub
+pre-releases tagged `vX.Y.Z-rc.N` (for example `v0.6.0-rc.1`, `v0.3.3-rc.2`).
+
+### `build-snapshot.yml` — the hand-distributed build
+
+Manually dispatched. Produces a release-signed build from an arbitrary commit
+with no tag behind it, uploaded as a 14-day artifact rather than published.
+
+Use it when someone needs a real, installable build of work in progress and you
+do not want a public pre-release for it. Every run consumes a version code from
+the shared counter, so it is not something to run per pull request.
+
+---
+
+## Differences
+
+| | `build-debug` | `build-release` | `build-snapshot` |
+|---|---|---|---|
+| Trigger | `pull_request`, `push` → `main` | `release: published` | `workflow_dispatch` |
+| Build type | debug | release | release |
+| **Version name** | `ci-<sha>` | the release tag verbatim (`v0.5.0`, `v0.6.0-rc.1`) | `snapshot-<sha>` |
+| **Version code** | `9999` (fallback from `version.properties`) | `release_runs + snapshot_runs + 40` | `release_runs + snapshot_runs + 40` |
+| **Signing key** | default Android debug keystore | Play upload keystore (`gplay.keystore`) | Play upload keystore (`gplay.keystore`) |
+| **Firebase Crashlytics + Analytics** | **absent** | present | present |
+| Runs tests | yes (unit + instrumented) | no | no |
+| Artifact | `debug-artifacts-<name>`, 3 days; `netbird-aar`, 1 day | attached to the GitHub release | `snapshot-<sha>`, 14 days |
+| Permissions | `contents: read` | `contents: write`, `actions: read` | `contents: read`, `actions: read` |
+| Concurrency group | none | `android-version-code-lock` | `android-version-code-lock` |
+
+`<sha>` is the short commit hash of the `android-client` repository, not of the
+submodule.


### PR DESCRIPTION
## Description

- **Manual ad-hoc APK workflow** (`build-snapshot.yml`, `build-release.yml`, `build-android-lib.sh`, `docs/versioning.md`): a manually triggered workflow that builds a version-code-consistent APK for ad-hoc distribution, plus the versioning scheme documentation.
- **Pin gobind alongside gomobile** (`build-android-lib.sh`, `build-android/action.yml`): gomobile bind shells out to gobind, which `gomobile init` used to install from `@latest` while gomobile itself was pinned. Both tools are now installed at the revision from the submodule's `go.mod`, and the CI cache key names both so stale gomobile-only entries are not reused.
- **JDK from temurin**: resolving the `adopt` distribution fails outright since AdoptOpenJDK became Eclipse Temurin.
- **CI caching**: Go module cache keyed on `netbird/go.sum` and an Android NDK cache in the build action.

## Notes

- The `netbird` submodule stays at main's v0.77.0 pointer; its `go.mod` carries the `golang.org/x/mobile` pin the gobind logic resolves.
- The `build-debug.yml` change from the source branch (excluding the e2e test package from instrumented CI runs) is left out, as the e2e package does not exist on main yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manually triggered Android snapshot builds with signed APK and AAB artifacts available for 14 days.
  * Improved Android version naming and numbering across release and snapshot builds.
  * Added reliable setup and caching for Android and Go build tools.

* **Bug Fixes**
  * Improved builds from shallow checkouts and ensured dependencies use the correct versions.

* **Documentation**
  * Documented Android build workflows, versioning, signing, testing, and artifact retention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->