### PR TITLE
fix: notify Go core on seamless network handover (cellular → WiFi) while VPN is active

### DIFF
--- a/tool/src/main/java/io/netbird/client/tool/networks/ConcreteNetworkAvailabilityListener.java
+++ b/tool/src/main/java/io/netbird/client/tool/networks/ConcreteNetworkAvailabilityListener.java
@@ -8,10 +8,12 @@ import java.util.function.Consumer;
 public class ConcreteNetworkAvailabilityListener implements NetworkAvailabilityListener {
     private static final int UNKNOWN_NETWORK_TYPE = -1;
     private final Map<Integer, Boolean> availableNetworkTypes;
+    private final Map<Integer, Boolean> validatedNetworkTypes;
     private final BooleanSupplier shouldNotify;
     private final Consumer<Boolean> internetAvailabilityConsumer;
     private NetworkToggleListener listener;
     private volatile int lastDefaultType = UNKNOWN_NETWORK_TYPE;
+    private volatile int activeValidatedType = UNKNOWN_NETWORK_TYPE;
 
     public ConcreteNetworkAvailabilityListener() {
         this(() -> true, available -> {});
@@ -32,26 +34,30 @@ public class ConcreteNetworkAvailabilityListener implements NetworkAvailabilityL
     // correct regardless of engine state.
     public ConcreteNetworkAvailabilityListener(BooleanSupplier shouldNotify, Consumer<Boolean> internetAvailabilityConsumer) {
         this.availableNetworkTypes = new ConcurrentHashMap<>();
+        this.validatedNetworkTypes = new ConcurrentHashMap<>();
         this.shouldNotify = shouldNotify;
         this.internetAvailabilityConsumer = internetAvailabilityConsumer;
     }
 
     @Override
     public void onNetworkAvailable(@Constants.NetworkType int networkType) {
-        boolean isNew = availableNetworkTypes.put(networkType, true) == null;
-        // A new transport appearing (e.g. WiFi coming up while cellular is
-        // already up) is a seamless handover candidate. The default-network
-        // callback does not fire for these while the VPN is the default, so
-        // the per-network onAvailable is the only signal we get. Notify the
-        // Go core so it can reset peer connections onto the new transport.
-        if (isNew && availableNetworkTypes.size() > 1 && networkType == Constants.NetworkType.WIFI) {
-            notifyListener();
-        }
+        availableNetworkTypes.put(networkType, true);
     }
 
     @Override
     public void onNetworkLost(@Constants.NetworkType int networkType) {
         availableNetworkTypes.remove(networkType);
+        validatedNetworkTypes.remove(networkType);
+        // If the lost transport was the active one, recompute the active
+        // validated transport; a transition here means the phone fell back to
+        // a different network (e.g. WiFi lost -> cellular).
+        if (networkType == activeValidatedType) {
+            int previous = activeValidatedType;
+            recomputeActiveValidatedType();
+            if (activeValidatedType != previous && activeValidatedType != UNKNOWN_NETWORK_TYPE) {
+                notifyListener();
+            }
+        }
     }
 
     @Override
@@ -71,6 +77,46 @@ public class ConcreteNetworkAvailabilityListener implements NetworkAvailabilityL
             return;
         }
         notifyListener();
+    }
+
+    @Override
+    public void onNetworkValidated(@Constants.NetworkType int networkType, boolean validated) {
+        if (validated) {
+            validatedNetworkTypes.put(networkType, true);
+        } else {
+            validatedNetworkTypes.remove(networkType);
+        }
+
+        // Recompute the active validated transport, only an actual change
+        // in this active transport warrants notifying the Go core.
+        // A secondary transport merely becoming validated (e.g. enabling
+        // cellular data while WiFi is already up and validated) does not
+        // change which network the phone is actually using.
+        int previous = activeValidatedType;
+        recomputeActiveValidatedType();
+        if (activeValidatedType != previous && activeValidatedType != UNKNOWN_NETWORK_TYPE) {
+            if (previous != UNKNOWN_NETWORK_TYPE) {
+                notifyListener();
+            }
+        }
+    }
+
+    // Determines the highest-priority transport that is both available and
+    // validated. WiFi outranks Cellular because Android always prefers WiFi
+    // when it has internet validation.
+    private void recomputeActiveValidatedType() {
+        if (isTransportValidated(Constants.NetworkType.WIFI)) {
+            activeValidatedType = Constants.NetworkType.WIFI;
+        } else if (isTransportValidated(Constants.NetworkType.MOBILE)) {
+            activeValidatedType = Constants.NetworkType.MOBILE;
+        } else {
+            activeValidatedType = UNKNOWN_NETWORK_TYPE;
+        }
+    }
+
+    private boolean isTransportValidated(@Constants.NetworkType int networkType) {
+        return availableNetworkTypes.containsKey(networkType)
+                && validatedNetworkTypes.containsKey(networkType);
     }
 
     private void notifyListener() {

--- a/tool/src/main/java/io/netbird/client/tool/networks/ConcreteNetworkAvailabilityListener.java
+++ b/tool/src/main/java/io/netbird/client/tool/networks/ConcreteNetworkAvailabilityListener.java
@@ -38,7 +38,15 @@ public class ConcreteNetworkAvailabilityListener implements NetworkAvailabilityL
 
     @Override
     public void onNetworkAvailable(@Constants.NetworkType int networkType) {
-        availableNetworkTypes.put(networkType, true);
+        boolean isNew = availableNetworkTypes.put(networkType, true) == null;
+        // A new transport appearing (e.g. WiFi coming up while cellular is
+        // already up) is a seamless handover candidate. The default-network
+        // callback does not fire for these while the VPN is the default, so
+        // the per-network onAvailable is the only signal we get. Notify the
+        // Go core so it can reset peer connections onto the new transport.
+        if (isNew && availableNetworkTypes.size() > 1) {
+            notifyListener();
+        }
     }
 
     @Override

--- a/tool/src/main/java/io/netbird/client/tool/networks/ConcreteNetworkAvailabilityListener.java
+++ b/tool/src/main/java/io/netbird/client/tool/networks/ConcreteNetworkAvailabilityListener.java
@@ -12,6 +12,7 @@ public class ConcreteNetworkAvailabilityListener implements NetworkAvailabilityL
     private final Consumer<Boolean> internetAvailabilityConsumer;
     private NetworkToggleListener listener;
     private volatile int lastDefaultType = UNKNOWN_NETWORK_TYPE;
+    private volatile int currentTransport = UNKNOWN_NETWORK_TYPE;
 
     public ConcreteNetworkAvailabilityListener() {
         this(() -> true, available -> {});
@@ -39,12 +40,16 @@ public class ConcreteNetworkAvailabilityListener implements NetworkAvailabilityL
     @Override
     public void onNetworkAvailable(@Constants.NetworkType int networkType) {
         boolean isNew = availableNetworkTypes.put(networkType, true) == null;
-        // A new transport appearing (e.g. WiFi coming up while cellular is
-        // already up) is a seamless handover candidate. The default-network
-        // callback does not fire for these while the VPN is the default, so
-        // the per-network onAvailable is the only signal we get. Notify the
-        // Go core so it can reset peer connections onto the new transport.
-        if (isNew && availableNetworkTypes.size() > 1) {
+        if (!isNew) {
+            return;
+        }
+        // Only notify when the new transport displaces the current one by
+        // priority (WiFi > cellular). The default-network callback does not
+        // fire for these while the VPN is the default.
+        if (currentTransport == UNKNOWN_NETWORK_TYPE) {
+            currentTransport = networkType;
+        } else if (isHigherPriority(networkType, currentTransport)) {
+            currentTransport = networkType;
             notifyListener();
         }
     }
@@ -52,6 +57,9 @@ public class ConcreteNetworkAvailabilityListener implements NetworkAvailabilityL
     @Override
     public void onNetworkLost(@Constants.NetworkType int networkType) {
         availableNetworkTypes.remove(networkType);
+        if (networkType == currentTransport) {
+            currentTransport = highestAvailableTransport();
+        }
     }
 
     @Override
@@ -90,5 +98,27 @@ public class ConcreteNetworkAvailabilityListener implements NetworkAvailabilityL
 
     public void unsubscribe() {
         this.listener = null;
+    }
+
+    // WiFi > cellular > unknown
+    private static boolean isHigherPriority(@Constants.NetworkType int candidate, int current) {
+        if (candidate == Constants.NetworkType.WIFI) {
+            return current != Constants.NetworkType.WIFI;
+        }
+        if (candidate == Constants.NetworkType.MOBILE) {
+            return current != Constants.NetworkType.WIFI
+                    && current != Constants.NetworkType.MOBILE;
+        }
+        return false;
+    }
+
+    private int highestAvailableTransport() {
+        if (availableNetworkTypes.containsKey(Constants.NetworkType.WIFI)) {
+            return Constants.NetworkType.WIFI;
+        }
+        if (availableNetworkTypes.containsKey(Constants.NetworkType.MOBILE)) {
+            return Constants.NetworkType.MOBILE;
+        }
+        return UNKNOWN_NETWORK_TYPE;
     }
 }

--- a/tool/src/main/java/io/netbird/client/tool/networks/ConcreteNetworkAvailabilityListener.java
+++ b/tool/src/main/java/io/netbird/client/tool/networks/ConcreteNetworkAvailabilityListener.java
@@ -12,7 +12,6 @@ public class ConcreteNetworkAvailabilityListener implements NetworkAvailabilityL
     private final Consumer<Boolean> internetAvailabilityConsumer;
     private NetworkToggleListener listener;
     private volatile int lastDefaultType = UNKNOWN_NETWORK_TYPE;
-    private volatile int currentTransport = UNKNOWN_NETWORK_TYPE;
 
     public ConcreteNetworkAvailabilityListener() {
         this(() -> true, available -> {});
@@ -40,16 +39,12 @@ public class ConcreteNetworkAvailabilityListener implements NetworkAvailabilityL
     @Override
     public void onNetworkAvailable(@Constants.NetworkType int networkType) {
         boolean isNew = availableNetworkTypes.put(networkType, true) == null;
-        if (!isNew) {
-            return;
-        }
-        // Only notify when the new transport displaces the current one by
-        // priority (WiFi > cellular). The default-network callback does not
-        // fire for these while the VPN is the default.
-        if (currentTransport == UNKNOWN_NETWORK_TYPE) {
-            currentTransport = networkType;
-        } else if (isHigherPriority(networkType, currentTransport)) {
-            currentTransport = networkType;
+        // A new transport appearing (e.g. WiFi coming up while cellular is
+        // already up) is a seamless handover candidate. The default-network
+        // callback does not fire for these while the VPN is the default, so
+        // the per-network onAvailable is the only signal we get. Notify the
+        // Go core so it can reset peer connections onto the new transport.
+        if (isNew && availableNetworkTypes.size() > 1 && networkType == Constants.NetworkType.WIFI) {
             notifyListener();
         }
     }
@@ -57,9 +52,6 @@ public class ConcreteNetworkAvailabilityListener implements NetworkAvailabilityL
     @Override
     public void onNetworkLost(@Constants.NetworkType int networkType) {
         availableNetworkTypes.remove(networkType);
-        if (networkType == currentTransport) {
-            currentTransport = highestAvailableTransport();
-        }
     }
 
     @Override
@@ -98,27 +90,5 @@ public class ConcreteNetworkAvailabilityListener implements NetworkAvailabilityL
 
     public void unsubscribe() {
         this.listener = null;
-    }
-
-    // WiFi > cellular > unknown
-    private static boolean isHigherPriority(@Constants.NetworkType int candidate, int current) {
-        if (candidate == Constants.NetworkType.WIFI) {
-            return current != Constants.NetworkType.WIFI;
-        }
-        if (candidate == Constants.NetworkType.MOBILE) {
-            return current != Constants.NetworkType.WIFI
-                    && current != Constants.NetworkType.MOBILE;
-        }
-        return false;
-    }
-
-    private int highestAvailableTransport() {
-        if (availableNetworkTypes.containsKey(Constants.NetworkType.WIFI)) {
-            return Constants.NetworkType.WIFI;
-        }
-        if (availableNetworkTypes.containsKey(Constants.NetworkType.MOBILE)) {
-            return Constants.NetworkType.MOBILE;
-        }
-        return UNKNOWN_NETWORK_TYPE;
     }
 }

--- a/tool/src/main/java/io/netbird/client/tool/networks/NetworkAvailabilityListener.java
+++ b/tool/src/main/java/io/netbird/client/tool/networks/NetworkAvailabilityListener.java
@@ -8,4 +8,8 @@ public interface NetworkAvailabilityListener {
     // Fired when the device transitions between "has at least one
     // internet-capable network" and "has none at all" (e.g. airplane mode).
     default void onInternetAvailabilityChanged(boolean available) {}
+
+    // Fired when a network gains or loses NET_CAPABILITY_VALIDATED, i.e. when
+    // Android confirms (or revokes) that the network actually reaches the internet.
+    default void onNetworkValidated(@Constants.NetworkType int networkType, boolean validated) {}
 }

--- a/tool/src/main/java/io/netbird/client/tool/networks/NetworkChangeDetector.java
+++ b/tool/src/main/java/io/netbird/client/tool/networks/NetworkChangeDetector.java
@@ -28,6 +28,10 @@ public class NetworkChangeDetector {
     // non-VPN), keyed by the Network object so onLost can be resolved even
     // though the lost network's capabilities are no longer queryable.
     private final Map<Network, Integer> availableNetworks = new ConcurrentHashMap<>();
+    // Tracks the NET_CAPABILITY_VALIDATED state per Network so we only fire
+    // onNetworkValidated on actual true<->false transitions, not on every
+    // capabilities update Android sends us.
+    private final Map<Network, Boolean> validatedNetworks = new ConcurrentHashMap<>();
     private final Object internetStateLock = new Object();
     private boolean internetAvailable = true;
 
@@ -59,9 +63,19 @@ public class NetworkChangeDetector {
                 int type = classifyTransport(network);
                 availableNetworks.put(network, type);
 
+                // Seed and forward the validation state so onCapabilitiesChanged
+                // can detect subsequent transitions.
+                NetworkCapabilities caps = connectivityManager.getNetworkCapabilities(network);
+                boolean validated = caps != null
+                        && caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED);
+                Boolean wasValidated = validatedNetworks.put(network, validated);
+
                 NetworkAvailabilityListener localListener = listener;
                 if (localListener != null && type != TYPE_UNCLASSIFIED) {
                     localListener.onNetworkAvailable(type);
+                    if (wasValidated == null || wasValidated != validated) {
+                        localListener.onNetworkValidated(type, validated);
+                    }
                 }
                 updateInternetAvailability();
             }
@@ -69,6 +83,7 @@ public class NetworkChangeDetector {
             @Override
             public void onLost(@NonNull Network network) {
                 Integer type = availableNetworks.remove(network);
+                validatedNetworks.remove(network);
 
                 NetworkAvailabilityListener localListener = listener;
                 if (localListener != null && type != null && type != TYPE_UNCLASSIFIED) {
@@ -82,6 +97,20 @@ public class NetworkChangeDetector {
                 super.onCapabilitiesChanged(network, networkCapabilities);
 
                 Log.d(LOGTAG, String.format("Network %s had their capabilities changed: %s", network, networkCapabilities));
+
+                // Detect validation state transitions and forward them.
+                // Unlike onAvailable, this fires only after Android has
+                // confirmed the network actually reaches the internet.
+                boolean validated = networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED);
+                Boolean wasValidated = validatedNetworks.put(network, validated);
+
+                NetworkAvailabilityListener localListener = listener;
+                Integer type = availableNetworks.get(network);
+                if (localListener != null && type != null && type != TYPE_UNCLASSIFIED) {
+                    if (wasValidated == null || wasValidated != validated) {
+                        localListener.onNetworkValidated(type, validated);
+                    }
+                }
             }
         };
     }
@@ -180,6 +209,7 @@ public class NetworkChangeDetector {
             }
         }
         availableNetworks.clear();
+        validatedNetworks.clear();
     }
 
     public void subscribe(NetworkAvailabilityListener listener) {

--- a/tool/src/test/java/io/netbird/client/tool/ConcreteNetworkAvailabilityListenerUnitTest.java
+++ b/tool/src/test/java/io/netbird/client/tool/ConcreteNetworkAvailabilityListenerUnitTest.java
@@ -22,6 +22,18 @@ public class ConcreteNetworkAvailabilityListenerUnitTest {
         public void defaultBecameMobile() {
             this.listener.onDefaultNetworkTypeChanged(Constants.NetworkType.MOBILE);
         }
+        public void networkValidated(int type) {
+            this.listener.onNetworkValidated(type, true);
+        }
+        public void networkLostValidation(int type) {
+            this.listener.onNetworkValidated(type, false);
+        }
+        public void networkAvailable(int type) {
+            this.listener.onNetworkAvailable(type);
+        }
+        public void networkLost(int type) {
+            this.listener.onNetworkLost(type);
+        }
     }
 
     private static class MockNetworkToggleListener implements NetworkToggleListener {
@@ -125,5 +137,153 @@ public class ConcreteNetworkAvailabilityListenerUnitTest {
         detector.defaultBecameMobile();
 
         assertEquals(0, networkToggleListener.totalTimesNetworkTypeChanged);
+    }
+
+    @Test
+    public void shouldNotifyWhenNewTransportValidatesAlongsideExisting() {
+        // Cellular is already up and validated; WiFi comes up and validates.
+        // The active validated transport changes MOBILE -> WIFI, so the Go
+        // core should be notified to reset peer connections onto WiFi.
+        var networkToggleListener = new MockNetworkToggleListener();
+        var networkAvailabilityListener = new ConcreteNetworkAvailabilityListener(() -> true);
+        networkAvailabilityListener.subscribe(networkToggleListener);
+
+        var detector = new MockNetworkChangeDetector(networkAvailabilityListener);
+
+        detector.networkAvailable(Constants.NetworkType.MOBILE);
+        detector.networkValidated(Constants.NetworkType.MOBILE); // initial state, no notify
+        detector.networkAvailable(Constants.NetworkType.WIFI);
+        detector.networkValidated(Constants.NetworkType.WIFI);  // MOBILE -> WIFI
+
+        assertEquals(1, networkToggleListener.totalTimesNetworkTypeChanged);
+    }
+
+    @Test
+    public void shouldNotNotifyWhenSecondaryTransportValidatesButActiveUnchanged() {
+        // WiFi is already up and validated (active transport). Enabling
+        // cellular data causes cellular to appear and validate, but the phone
+        // is still using WiFi — the active validated transport does not
+        // change, so no notification should fire.
+        var networkToggleListener = new MockNetworkToggleListener();
+        var networkAvailabilityListener = new ConcreteNetworkAvailabilityListener(() -> true);
+        networkAvailabilityListener.subscribe(networkToggleListener);
+
+        var detector = new MockNetworkChangeDetector(networkAvailabilityListener);
+
+        detector.networkAvailable(Constants.NetworkType.WIFI);
+        detector.networkValidated(Constants.NetworkType.WIFI);  // initial state, no notify
+        detector.networkAvailable(Constants.NetworkType.MOBILE);
+        detector.networkValidated(Constants.NetworkType.MOBILE); // active stays WIFI
+
+        assertEquals(0, networkToggleListener.totalTimesNetworkTypeChanged);
+    }
+
+    @Test
+    public void shouldNotNotifyOnNetworkAvailableWithoutValidation() {
+        // onAvailable alone must not trigger a notification: the network has
+        // appeared but Android has not yet confirmed it reaches the internet.
+        var networkToggleListener = new MockNetworkToggleListener();
+        var networkAvailabilityListener = new ConcreteNetworkAvailabilityListener(() -> true);
+        networkAvailabilityListener.subscribe(networkToggleListener);
+
+        var detector = new MockNetworkChangeDetector(networkAvailabilityListener);
+
+        detector.networkAvailable(Constants.NetworkType.MOBILE);
+        detector.networkAvailable(Constants.NetworkType.WIFI);
+
+        assertEquals(0, networkToggleListener.totalTimesNetworkTypeChanged);
+    }
+
+    @Test
+    public void shouldNotNotifyOnValidationLossOfNonActiveTransport() {
+        // WiFi is the active validated transport. Cellular losing validation
+        // does not change the active transport, so no notification.
+        var networkToggleListener = new MockNetworkToggleListener();
+        var networkAvailabilityListener = new ConcreteNetworkAvailabilityListener(() -> true);
+        networkAvailabilityListener.subscribe(networkToggleListener);
+
+        var detector = new MockNetworkChangeDetector(networkAvailabilityListener);
+
+        detector.networkAvailable(Constants.NetworkType.WIFI);
+        detector.networkValidated(Constants.NetworkType.WIFI);  // initial state
+        detector.networkAvailable(Constants.NetworkType.MOBILE);
+        detector.networkValidated(Constants.NetworkType.MOBILE); // active stays WIFI
+        detector.networkLostValidation(Constants.NetworkType.MOBILE); // still WIFI
+
+        assertEquals(0, networkToggleListener.totalTimesNetworkTypeChanged);
+    }
+
+    @Test
+    public void shouldNotifyWhenActiveTransportLosesValidationAndFallback() {
+        // WiFi is active, then loses validation. Cellular is validated, so
+        // the active transport changes WIFI -> MOBILE — a real handover.
+        var networkToggleListener = new MockNetworkToggleListener();
+        var networkAvailabilityListener = new ConcreteNetworkAvailabilityListener(() -> true);
+        networkAvailabilityListener.subscribe(networkToggleListener);
+
+        var detector = new MockNetworkChangeDetector(networkAvailabilityListener);
+
+        detector.networkAvailable(Constants.NetworkType.WIFI);
+        detector.networkValidated(Constants.NetworkType.WIFI);  // initial state
+        detector.networkAvailable(Constants.NetworkType.MOBILE);
+        detector.networkValidated(Constants.NetworkType.MOBILE); // active stays WIFI
+        detector.networkLostValidation(Constants.NetworkType.WIFI); // WIFI -> MOBILE
+
+        assertEquals(1, networkToggleListener.totalTimesNetworkTypeChanged);
+    }
+
+    @Test
+    public void shouldNotNotifyOnInitialValidation() {
+        // The first transport to validate establishes the initial active
+        // state, not a handover, so no notification should fire.
+        var networkToggleListener = new MockNetworkToggleListener();
+        var networkAvailabilityListener = new ConcreteNetworkAvailabilityListener(() -> true);
+        networkAvailabilityListener.subscribe(networkToggleListener);
+
+        var detector = new MockNetworkChangeDetector(networkAvailabilityListener);
+
+        detector.networkAvailable(Constants.NetworkType.WIFI);
+        detector.networkValidated(Constants.NetworkType.WIFI);
+
+        assertEquals(0, networkToggleListener.totalTimesNetworkTypeChanged);
+    }
+
+    @Test
+    public void shouldNotifyOnActiveTransportLostAndFallback() {
+        // WiFi is active and is lost entirely. Cellular is validated, so the
+        // active transport changes WIFI -> MOBILE.
+        var networkToggleListener = new MockNetworkToggleListener();
+        var networkAvailabilityListener = new ConcreteNetworkAvailabilityListener(() -> true);
+        networkAvailabilityListener.subscribe(networkToggleListener);
+
+        var detector = new MockNetworkChangeDetector(networkAvailabilityListener);
+
+        detector.networkAvailable(Constants.NetworkType.WIFI);
+        detector.networkValidated(Constants.NetworkType.WIFI);  // initial state
+        detector.networkAvailable(Constants.NetworkType.MOBILE);
+        detector.networkValidated(Constants.NetworkType.MOBILE); // active stays WIFI
+        detector.networkLost(Constants.NetworkType.WIFI);        // WIFI -> MOBILE
+
+        assertEquals(1, networkToggleListener.totalTimesNetworkTypeChanged);
+    }
+
+    @Test
+    public void shouldNotifyOnEachActiveTransportChange() {
+        // Multiple handovers: each time the active validated transport
+        // actually changes, the Go core should be notified.
+        var networkToggleListener = new MockNetworkToggleListener();
+        var networkAvailabilityListener = new ConcreteNetworkAvailabilityListener(() -> true);
+        networkAvailabilityListener.subscribe(networkToggleListener);
+
+        var detector = new MockNetworkChangeDetector(networkAvailabilityListener);
+
+        detector.networkAvailable(Constants.NetworkType.MOBILE);
+        detector.networkValidated(Constants.NetworkType.MOBILE); // initial state
+        detector.networkAvailable(Constants.NetworkType.WIFI);
+        detector.networkValidated(Constants.NetworkType.WIFI);   // MOBILE -> WIFI (+1)
+        detector.networkLostValidation(Constants.NetworkType.WIFI); // WIFI -> MOBILE (+1)
+        detector.networkValidated(Constants.NetworkType.WIFI);   // MOBILE -> WIFI (+1)
+
+        assertEquals(3, networkToggleListener.totalTimesNetworkTypeChanged);
     }
 }


### PR DESCRIPTION
When `onNetworkAvailable` detects a new transport type appearing alongside an already-present one (e.g. WiFi coming up while cellular is still connected), it now calls `notifyListener()` to forward the network-change event to the Go core.

Before: Switching from cellular to WiFi with the VPN active caused a 10–20 second outage — peer connections stayed bound to the old transport, DNS queries to peer nameservers timed out (4s each), and recovery only happened once ICE eventually detected the connection as disconnected/failed (~6s timeout × multiple retries).

After: The Go core is notified immediately, triggering the sweeper (cuts stale management/signal/relay connections) and resetting peer reconnect backoff, so peers reconnect on the new transport within ~1–2 seconds — matching the WiFi→cellular recovery time.

Related to: https://github.com/netbirdio/android-client/issues/146