### PR TITLE
Feat/split tunneling

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,18 @@
         android:name="io.netbird.permission.NOTIFICATION"
         android:protectionLevel="signature" />
 
+    <!--
+        Split tunnelling needs to show the user a list of apps. Resolving the
+        launcher intent keeps that to apps with an icon, which avoids
+        QUERY_ALL_PACKAGES and the Play declaration it drags along.
+    -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent>
+    </queries>
+
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />

--- a/app/src/main/java/io/netbird/client/MainActivity.java
+++ b/app/src/main/java/io/netbird/client/MainActivity.java
@@ -583,6 +583,17 @@ public class MainActivity extends AppCompatActivity implements ServiceAccessor, 
     }
 
     @Override
+    public void applySplitTunneling() {
+        if (mBinder == null) {
+            // Nothing is running to rebuild; the new selection is read when the
+            // tunnel is next created.
+            return;
+        }
+
+        mBinder.applySplitTunneling();
+    }
+
+    @Override
     public void selectRoute(String route) throws Exception {
         if (mBinder == null) {
             throw new Exception("VPN service not connected");

--- a/app/src/main/java/io/netbird/client/ServiceAccessor.java
+++ b/app/src/main/java/io/netbird/client/ServiceAccessor.java
@@ -22,6 +22,9 @@ public interface ServiceAccessor {
 
     void stopEngine();
 
+    /** Rebuilds the tunnel so a split tunnelling change applies without reconnecting. */
+    void applySplitTunneling();
+
     void selectRoute(String route) throws Exception;
     void deselectRoute(String route) throws Exception;
 

--- a/app/src/main/java/io/netbird/client/ui/settings/SettingsFragment.java
+++ b/app/src/main/java/io/netbird/client/ui/settings/SettingsFragment.java
@@ -52,6 +52,9 @@ public class SettingsFragment extends Fragment {
         binding.rowAdvanced.setOnClickListener(v ->
                 navController.navigate(R.id.nav_advanced));
 
+        binding.rowSplitTunneling.setOnClickListener(v ->
+                navController.navigate(R.id.nav_split_tunneling));
+
         binding.rowLanguage.setOnClickListener(v ->
                 new LanguagePickerSheet().show(getChildFragmentManager(), "language_picker"));
 

--- a/app/src/main/java/io/netbird/client/ui/splittunneling/AppEntry.java
+++ b/app/src/main/java/io/netbird/client/ui/splittunneling/AppEntry.java
@@ -1,0 +1,29 @@
+package io.netbird.client.ui.splittunneling;
+
+import android.graphics.drawable.Drawable;
+
+/** One installed application, as shown in the split tunnelling list. */
+public class AppEntry {
+
+    private final String packageName;
+    private final String label;
+    private final Drawable icon;
+
+    public AppEntry(String packageName, String label, Drawable icon) {
+        this.packageName = packageName;
+        this.label = label;
+        this.icon = icon;
+    }
+
+    public String getPackageName() {
+        return packageName;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public Drawable getIcon() {
+        return icon;
+    }
+}

--- a/app/src/main/java/io/netbird/client/ui/splittunneling/AppListAdapter.java
+++ b/app/src/main/java/io/netbird/client/ui/splittunneling/AppListAdapter.java
@@ -1,0 +1,108 @@
+package io.netbird.client.ui.splittunneling;
+
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import io.netbird.client.databinding.ListItemAppBinding;
+
+public class AppListAdapter extends RecyclerView.Adapter<AppListAdapter.AppViewHolder> {
+
+    public interface OnAppToggledListener {
+        void onAppToggled(String packageName, boolean selected);
+    }
+
+    private final List<AppEntry> apps = new ArrayList<>();
+    private final List<AppEntry> filteredApps = new ArrayList<>();
+    private final OnAppToggledListener toggleListener;
+
+    private Set<String> selected;
+    private String filterQueryString = "";
+
+    public AppListAdapter(Set<String> selected, OnAppToggledListener toggleListener) {
+        this.selected = selected;
+        this.toggleListener = toggleListener;
+    }
+
+    public void submitApps(List<AppEntry> newApps) {
+        apps.clear();
+        apps.addAll(newApps);
+        applyFilter();
+    }
+
+    /** Called when the mode changes, which swaps which of the two lists is shown. */
+    public void setSelected(Set<String> selected) {
+        this.selected = selected;
+        notifyDataSetChanged();
+    }
+
+    public void filterBySearchQuery(String query) {
+        filterQueryString = query == null ? "" : query;
+        applyFilter();
+    }
+
+    private void applyFilter() {
+        filteredApps.clear();
+        if (filterQueryString.isEmpty()) {
+            filteredApps.addAll(apps);
+        } else {
+            String needle = filterQueryString.toLowerCase(Locale.getDefault());
+            for (AppEntry app : apps) {
+                if (app.getLabel().toLowerCase(Locale.getDefault()).contains(needle)) {
+                    filteredApps.add(app);
+                }
+            }
+        }
+        notifyDataSetChanged();
+    }
+
+    @NonNull
+    @Override
+    public AppViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        ListItemAppBinding binding = ListItemAppBinding.inflate(
+                LayoutInflater.from(parent.getContext()), parent, false);
+        return new AppViewHolder(binding);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull AppViewHolder holder, int position) {
+        holder.bind(filteredApps.get(position));
+    }
+
+    @Override
+    public int getItemCount() {
+        return filteredApps.size();
+    }
+
+    class AppViewHolder extends RecyclerView.ViewHolder {
+
+        private final ListItemAppBinding binding;
+
+        AppViewHolder(ListItemAppBinding binding) {
+            super(binding.getRoot());
+            this.binding = binding;
+        }
+
+        void bind(AppEntry app) {
+            binding.appName.setText(app.getLabel());
+            binding.appPackage.setText(app.getPackageName());
+            binding.appIcon.setImageDrawable(app.getIcon());
+
+            // Cleared before setChecked so recycling a row into a different app
+            // cannot fire a toggle the user never made.
+            binding.switchControl.setOnCheckedChangeListener(null);
+            binding.switchControl.setChecked(selected.contains(app.getPackageName()));
+            binding.switchControl.setOnCheckedChangeListener((buttonView, isChecked) ->
+                    toggleListener.onAppToggled(app.getPackageName(), isChecked));
+
+            binding.getRoot().setOnClickListener(v -> binding.switchControl.toggle());
+        }
+    }
+}

--- a/app/src/main/java/io/netbird/client/ui/splittunneling/SplitTunnelModeSheet.java
+++ b/app/src/main/java/io/netbird/client/ui/splittunneling/SplitTunnelModeSheet.java
@@ -1,0 +1,78 @@
+package io.netbird.client.ui.splittunneling;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
+
+import io.netbird.client.databinding.SheetSplitTunnelModeBinding;
+import io.netbird.client.tool.SplitTunnelConfig;
+
+public class SplitTunnelModeSheet extends BottomSheetDialogFragment {
+
+    public interface OnModeChangedListener {
+        void onModeChanged(SplitTunnelConfig.Mode mode);
+    }
+
+    private static final String ARG_MODE = "mode";
+
+    private SheetSplitTunnelModeBinding binding;
+
+    public static SplitTunnelModeSheet newInstance(SplitTunnelConfig.Mode current) {
+        SplitTunnelModeSheet sheet = new SplitTunnelModeSheet();
+        Bundle args = new Bundle();
+        args.putString(ARG_MODE, current.name());
+        sheet.setArguments(args);
+        return sheet;
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        binding = SheetSplitTunnelModeBinding.inflate(inflater, container, false);
+
+        binding.modeRowOff.setOnClickListener(v -> pick(SplitTunnelConfig.Mode.OFF));
+        binding.modeRowExclude.setOnClickListener(v -> pick(SplitTunnelConfig.Mode.EXCLUDE));
+        binding.modeRowInclude.setOnClickListener(v -> pick(SplitTunnelConfig.Mode.INCLUDE));
+
+        showCheckmarkFor(currentMode());
+        return binding.getRoot();
+    }
+
+    private SplitTunnelConfig.Mode currentMode() {
+        Bundle args = getArguments();
+        if (args == null) {
+            return SplitTunnelConfig.Mode.OFF;
+        }
+        try {
+            return SplitTunnelConfig.Mode.valueOf(args.getString(ARG_MODE, SplitTunnelConfig.Mode.OFF.name()));
+        } catch (IllegalArgumentException e) {
+            return SplitTunnelConfig.Mode.OFF;
+        }
+    }
+
+    private void showCheckmarkFor(SplitTunnelConfig.Mode mode) {
+        binding.modeCheckOff.setVisibility(mode == SplitTunnelConfig.Mode.OFF ? View.VISIBLE : View.INVISIBLE);
+        binding.modeCheckExclude.setVisibility(mode == SplitTunnelConfig.Mode.EXCLUDE ? View.VISIBLE : View.INVISIBLE);
+        binding.modeCheckInclude.setVisibility(mode == SplitTunnelConfig.Mode.INCLUDE ? View.VISIBLE : View.INVISIBLE);
+    }
+
+    private void pick(SplitTunnelConfig.Mode mode) {
+        if (getParentFragment() instanceof OnModeChangedListener) {
+            ((OnModeChangedListener) getParentFragment()).onModeChanged(mode);
+        }
+        dismiss();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
+    }
+}

--- a/app/src/main/java/io/netbird/client/ui/splittunneling/SplitTunnelingFragment.java
+++ b/app/src/main/java/io/netbird/client/ui/splittunneling/SplitTunnelingFragment.java
@@ -1,0 +1,188 @@
+package io.netbird.client.ui.splittunneling;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.recyclerview.widget.LinearLayoutManager;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import io.netbird.client.R;
+import io.netbird.client.ServiceAccessor;
+import io.netbird.client.databinding.FragmentSplitTunnelingBinding;
+import io.netbird.client.tool.Preferences;
+import io.netbird.client.tool.SplitTunnelConfig;
+
+/**
+ * Lets the user say which applications the tunnel carries.
+ *
+ * Every change is written straight through and handed to the service, which
+ * rebuilds the tunnel in place — there is no save button and no reconnection to
+ * ask for.
+ */
+public class SplitTunnelingFragment extends Fragment
+        implements SplitTunnelModeSheet.OnModeChangedListener, AppListAdapter.OnAppToggledListener {
+
+    private FragmentSplitTunnelingBinding binding;
+    private SplitTunnelingViewModel viewModel;
+    private AppListAdapter adapter;
+    private Preferences preferences;
+    private ServiceAccessor serviceAccessor;
+
+    private SplitTunnelConfig.Mode mode = SplitTunnelConfig.Mode.OFF;
+    private final Set<String> excluded = new HashSet<>();
+    private final Set<String> included = new HashSet<>();
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+        if (context instanceof ServiceAccessor) {
+            serviceAccessor = (ServiceAccessor) context;
+        } else {
+            throw new RuntimeException(context + " must implement ServiceAccessor");
+        }
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        binding = FragmentSplitTunnelingBinding.inflate(inflater, container, false);
+        return binding.getRoot();
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        preferences = new Preferences(requireContext());
+        SplitTunnelConfig stored = preferences.getSplitTunnelConfig();
+        mode = stored.getMode();
+        excluded.addAll(stored.getExcluded());
+        included.addAll(stored.getIncluded());
+
+        adapter = new AppListAdapter(activeSelection(), this);
+        binding.appsRecyclerView.setLayoutManager(new LinearLayoutManager(requireContext()));
+        binding.appsRecyclerView.setAdapter(adapter);
+
+        binding.rowMode.setOnClickListener(v ->
+                SplitTunnelModeSheet.newInstance(mode).show(getChildFragmentManager(), "split_tunnel_mode"));
+
+        binding.searchView.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                adapter.filterBySearchQuery(s.toString());
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+            }
+        });
+
+        viewModel = new ViewModelProvider(this).get(SplitTunnelingViewModel.class);
+        viewModel.getApps().observe(getViewLifecycleOwner(), apps -> {
+            pruneUninstalled(apps);
+            adapter.submitApps(apps);
+            binding.loadingIndicator.setVisibility(View.GONE);
+        });
+        viewModel.loadApps();
+
+        renderMode();
+    }
+
+    @Override
+    public void onModeChanged(SplitTunnelConfig.Mode newMode) {
+        if (newMode == mode) {
+            return;
+        }
+        mode = newMode;
+        // Both selections are kept, so switching back and forth does not make the
+        // user pick their apps again.
+        save();
+        adapter.setSelected(activeSelection());
+        renderMode();
+    }
+
+    @Override
+    public void onAppToggled(String packageName, boolean selected) {
+        Set<String> selection = activeSelection();
+        if (selected) {
+            selection.add(packageName);
+        } else {
+            selection.remove(packageName);
+        }
+        save();
+        renderWarning();
+    }
+
+    private Set<String> activeSelection() {
+        return mode == SplitTunnelConfig.Mode.INCLUDE ? included : excluded;
+    }
+
+    private void save() {
+        preferences.saveSplitTunnelConfig(new SplitTunnelConfig(mode, excluded, included));
+        serviceAccessor.applySplitTunneling();
+    }
+
+    /**
+     * Drops packages that were picked and later uninstalled. The tunnel already
+     * ignores them, but leaving them in storage would silently re-apply them if
+     * the app were installed again.
+     */
+    private void pruneUninstalled(java.util.List<AppEntry> apps) {
+        Set<String> installed = new HashSet<>();
+        for (AppEntry app : apps) {
+            installed.add(app.getPackageName());
+        }
+
+        boolean changed = excluded.retainAll(installed);
+        changed |= included.retainAll(installed);
+        if (changed) {
+            preferences.saveSplitTunnelConfig(new SplitTunnelConfig(mode, excluded, included));
+        }
+    }
+
+    private void renderMode() {
+        int label;
+        if (mode == SplitTunnelConfig.Mode.EXCLUDE) {
+            label = R.string.split_tunneling_mode_exclude;
+        } else if (mode == SplitTunnelConfig.Mode.INCLUDE) {
+            label = R.string.split_tunneling_mode_include;
+        } else {
+            label = R.string.split_tunneling_mode_off;
+        }
+        binding.currentModeName.setText(label);
+
+        boolean listUsable = mode != SplitTunnelConfig.Mode.OFF;
+        binding.searchView.setEnabled(listUsable);
+        binding.appsRecyclerView.setVisibility(listUsable ? View.VISIBLE : View.GONE);
+        binding.modeOffHint.setVisibility(listUsable ? View.GONE : View.VISIBLE);
+
+        renderWarning();
+    }
+
+    private void renderWarning() {
+        boolean emptyAllowlist = mode == SplitTunnelConfig.Mode.INCLUDE && included.isEmpty();
+        binding.emptyIncludeWarning.setVisibility(emptyAllowlist ? View.VISIBLE : View.GONE);
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
+    }
+}

--- a/app/src/main/java/io/netbird/client/ui/splittunneling/SplitTunnelingFragment.java
+++ b/app/src/main/java/io/netbird/client/ui/splittunneling/SplitTunnelingFragment.java
@@ -2,11 +2,13 @@ package io.netbird.client.ui.splittunneling;
 
 import android.content.Context;
 import android.os.Bundle;
+import android.util.Log;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -20,8 +22,8 @@ import java.util.Set;
 import io.netbird.client.R;
 import io.netbird.client.ServiceAccessor;
 import io.netbird.client.databinding.FragmentSplitTunnelingBinding;
-import io.netbird.client.tool.Preferences;
 import io.netbird.client.tool.SplitTunnelConfig;
+import io.netbird.client.tool.SplitTunnelStore;
 
 /**
  * Lets the user say which applications the tunnel carries.
@@ -33,10 +35,12 @@ import io.netbird.client.tool.SplitTunnelConfig;
 public class SplitTunnelingFragment extends Fragment
         implements SplitTunnelModeSheet.OnModeChangedListener, AppListAdapter.OnAppToggledListener {
 
+    private static final String LOGTAG = "SplitTunnelingFragment";
+
     private FragmentSplitTunnelingBinding binding;
     private SplitTunnelingViewModel viewModel;
     private AppListAdapter adapter;
-    private Preferences preferences;
+    private SplitTunnelStore store;
     private ServiceAccessor serviceAccessor;
 
     private SplitTunnelConfig.Mode mode = SplitTunnelConfig.Mode.OFF;
@@ -65,8 +69,8 @@ public class SplitTunnelingFragment extends Fragment
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        preferences = new Preferences(requireContext());
-        SplitTunnelConfig stored = preferences.getSplitTunnelConfig();
+        store = new SplitTunnelStore(requireContext());
+        SplitTunnelConfig stored = store.load();
         mode = stored.getMode();
         excluded.addAll(stored.getExcluded());
         included.addAll(stored.getIncluded());
@@ -134,8 +138,22 @@ public class SplitTunnelingFragment extends Fragment
     }
 
     private void save() {
-        preferences.saveSplitTunnelConfig(new SplitTunnelConfig(mode, excluded, included));
-        serviceAccessor.applySplitTunneling();
+        if (persist()) {
+            serviceAccessor.applySplitTunneling();
+        }
+    }
+
+    /** @return false when the store refused the write, so nothing was changed. */
+    private boolean persist() {
+        try {
+            store.save(new SplitTunnelConfig(mode, excluded, included));
+            return true;
+        } catch (Exception e) {
+            Log.e(LOGTAG, "could not save the split tunnelling settings", e);
+            Toast.makeText(requireContext(), getString(R.string.error_generic, e.toString()),
+                    Toast.LENGTH_SHORT).show();
+            return false;
+        }
     }
 
     /**
@@ -152,7 +170,7 @@ public class SplitTunnelingFragment extends Fragment
         boolean changed = excluded.retainAll(installed);
         changed |= included.retainAll(installed);
         if (changed) {
-            preferences.saveSplitTunnelConfig(new SplitTunnelConfig(mode, excluded, included));
+            persist();
         }
     }
 

--- a/app/src/main/java/io/netbird/client/ui/splittunneling/SplitTunnelingViewModel.java
+++ b/app/src/main/java/io/netbird/client/ui/splittunneling/SplitTunnelingViewModel.java
@@ -1,0 +1,92 @@
+package io.netbird.client.ui.splittunneling;
+
+import android.app.Application;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.AndroidViewModel;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Builds the list of applications the user can pick from.
+ *
+ * Reading labels and icons hits the package manager once per app, which is slow
+ * enough to drop frames on a loaded device, so the whole list is resolved off the
+ * main thread and kept for as long as the screen lives.
+ */
+public class SplitTunnelingViewModel extends AndroidViewModel {
+
+    private final MutableLiveData<List<AppEntry>> apps = new MutableLiveData<>();
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private boolean loadStarted;
+
+    public SplitTunnelingViewModel(@NonNull Application application) {
+        super(application);
+    }
+
+    public LiveData<List<AppEntry>> getApps() {
+        return apps;
+    }
+
+    public void loadApps() {
+        if (loadStarted) {
+            return;
+        }
+        loadStarted = true;
+        executor.execute(() -> apps.postValue(queryLaunchableApps()));
+    }
+
+    /**
+     * Only apps with a launcher entry are listed. That is what the manifest's
+     * {@code <queries>} block makes visible, and it keeps the screen clear of the
+     * package manager's long tail of services the user has no opinion about —
+     * without asking for QUERY_ALL_PACKAGES, which Play treats as sensitive.
+     */
+    private List<AppEntry> queryLaunchableApps() {
+        PackageManager packageManager = getApplication().getPackageManager();
+
+        Intent launcherIntent = new Intent(Intent.ACTION_MAIN);
+        launcherIntent.addCategory(Intent.CATEGORY_LAUNCHER);
+
+        List<ResolveInfo> resolved = packageManager.queryIntentActivities(launcherIntent, 0);
+        List<AppEntry> entries = new ArrayList<>(resolved.size());
+        Set<String> seen = new HashSet<>();
+
+        // This app is left out on purpose: an INCLUDE selection always carries it
+        // so the built-in SSH client can reach peers, so a toggle for it would
+        // claim an effect it does not have.
+        String ownPackage = getApplication().getPackageName();
+
+        for (ResolveInfo info : resolved) {
+            String packageName = info.activityInfo.packageName;
+            if (packageName.equals(ownPackage) || !seen.add(packageName)) {
+                continue;
+            }
+            entries.add(new AppEntry(
+                    packageName,
+                    info.loadLabel(packageManager).toString(),
+                    info.loadIcon(packageManager)));
+        }
+
+        entries.sort(Comparator.comparing(entry -> entry.getLabel().toLowerCase(Locale.getDefault())));
+        return entries;
+    }
+
+    @Override
+    protected void onCleared() {
+        super.onCleared();
+        executor.shutdownNow();
+    }
+}

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -153,6 +153,45 @@
         <include layout="@layout/list_item_setting_divider" />
 
         <LinearLayout
+            android:id="@+id/row_split_tunneling"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/settings_row_bg"
+            android:clickable="true"
+            android:focusable="true"
+            android:gravity="center_vertical"
+            android:minHeight="56dp"
+            android:orientation="horizontal"
+            android:paddingStart="20dp"
+            android:paddingEnd="16dp">
+
+            <ImageView
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:contentDescription="@null"
+                android:src="@drawable/ic_menu_advanced"
+                app:tint="@color/nb_orange" />
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_weight="1"
+                android:text="@string/menu_split_tunneling"
+                android:textColor="@color/nb_txt"
+                android:textSize="16sp" />
+
+            <ImageView
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:contentDescription="@null"
+                android:src="@drawable/ic_chevron_right"
+                app:tint="@color/nb_txt_light" />
+        </LinearLayout>
+
+        <include layout="@layout/list_item_setting_divider" />
+
+        <LinearLayout
             android:id="@+id/row_language"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_split_tunneling.xml
+++ b/app/src/main/res/layout/fragment_split_tunneling.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/nb_bg_peers"
+    tools:context=".ui.splittunneling.SplitTunnelingFragment">
+
+    <LinearLayout
+        android:id="@+id/row_mode"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@drawable/settings_row_bg"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center_vertical"
+        android:minHeight="56dp"
+        android:orientation="horizontal"
+        android:paddingStart="20dp"
+        android:paddingEnd="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/split_tunneling_mode_title"
+            android:textColor="@color/nb_txt"
+            android:textSize="16sp" />
+
+        <TextView
+            android:id="@+id/current_mode_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:textColor="@color/nb_txt_light"
+            android:textSize="16sp"
+            tools:text="Exclude" />
+
+        <ImageView
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:layout_marginStart="8dp"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_chevron_right"
+            app:tint="@color/nb_txt_light" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/mode_off_hint"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="24dp"
+        android:layout_marginEnd="20dp"
+        android:text="@string/split_tunneling_mode_off_hint"
+        android:textAlignment="center"
+        android:textColor="@color/nb_txt_light"
+        android:textSize="14sp"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/row_mode"
+        tools:visibility="visible" />
+
+    <TextView
+        android:id="@+id/empty_include_warning"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="12dp"
+        android:layout_marginEnd="20dp"
+        android:text="@string/split_tunneling_empty_include_warning"
+        android:textColor="@color/nb_orange"
+        android:textSize="13sp"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/mode_off_hint"
+        tools:visibility="visible" />
+
+    <EditText
+        android:id="@+id/search_view"
+        android:layout_width="0dp"
+        android:layout_height="48dp"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="20dp"
+        android:autofillHints=""
+        android:background="@drawable/search_bg"
+        android:drawableStart="@drawable/search"
+        android:drawablePadding="10dp"
+        android:hint="@string/split_tunneling_hint_search_apps"
+        android:inputType="text"
+        android:paddingStart="15dp"
+        android:paddingEnd="15dp"
+        android:textColor="@color/nb_txt"
+        android:textColorHint="@color/nb_txt_light"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/empty_include_warning" />
+
+    <ProgressBar
+        android:id="@+id/loading_indicator"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/search_view" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/apps_recycler_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="12dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/search_view"
+        tools:listitem="@layout/list_item_app" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/list_item_app.xml
+++ b/app/src/main/res/layout/list_item_app.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/settings_row_bg"
+    android:clickable="true"
+    android:focusable="true"
+    android:gravity="center_vertical"
+    android:minHeight="64dp"
+    android:orientation="horizontal"
+    android:paddingStart="20dp"
+    android:paddingEnd="16dp"
+    android:paddingTop="8dp"
+    android:paddingBottom="8dp">
+
+    <ImageView
+        android:id="@+id/app_icon"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:contentDescription="@null"
+        tools:src="@mipmap/ic_launcher" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="12dp"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/app_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="@color/nb_txt"
+            android:textSize="16sp"
+            tools:text="Firefox" />
+
+        <TextView
+            android:id="@+id/app_package"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="@color/nb_txt_light"
+            android:textSize="12sp"
+            tools:text="org.mozilla.firefox" />
+    </LinearLayout>
+
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/switch_control"
+        style="@style/Widget.NetBird.Switch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+</LinearLayout>

--- a/app/src/main/res/layout/sheet_split_tunnel_mode.xml
+++ b/app/src/main/res/layout/sheet_split_tunnel_mode.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingBottom="16dp">
+
+    <View
+        android:layout_width="36dp"
+        android:layout_height="4dp"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="12dp"
+        android:layout_marginBottom="8dp"
+        android:background="@drawable/separator" />
+
+    <TextView
+        style="@style/SettingsSectionHeader"
+        android:text="@string/split_tunneling_mode_title" />
+
+    <LinearLayout
+        android:id="@+id/mode_row_off"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/sheet_row_bg"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center_vertical"
+        android:minHeight="56dp"
+        android:orientation="horizontal"
+        android:paddingStart="20dp"
+        android:paddingEnd="20dp">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:paddingTop="10dp"
+            android:paddingBottom="10dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/split_tunneling_mode_off"
+                android:textColor="@color/nb_txt"
+                android:textSize="16sp" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:text="@string/split_tunneling_mode_off_description"
+                android:textColor="@color/nb_txt_light"
+                android:textSize="12sp" />
+        </LinearLayout>
+
+        <ImageView
+            android:id="@+id/mode_check_off"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_check"
+            android:visibility="invisible"
+            app:tint="@color/nb_orange" />
+    </LinearLayout>
+
+    <include layout="@layout/list_item_setting_divider" />
+
+    <LinearLayout
+        android:id="@+id/mode_row_exclude"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/sheet_row_bg"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center_vertical"
+        android:minHeight="56dp"
+        android:orientation="horizontal"
+        android:paddingStart="20dp"
+        android:paddingEnd="20dp">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:paddingTop="10dp"
+            android:paddingBottom="10dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/split_tunneling_mode_exclude"
+                android:textColor="@color/nb_txt"
+                android:textSize="16sp" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:text="@string/split_tunneling_mode_exclude_description"
+                android:textColor="@color/nb_txt_light"
+                android:textSize="12sp" />
+        </LinearLayout>
+
+        <ImageView
+            android:id="@+id/mode_check_exclude"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_check"
+            android:visibility="invisible"
+            app:tint="@color/nb_orange" />
+    </LinearLayout>
+
+    <include layout="@layout/list_item_setting_divider" />
+
+    <LinearLayout
+        android:id="@+id/mode_row_include"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/sheet_row_bg"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center_vertical"
+        android:minHeight="56dp"
+        android:orientation="horizontal"
+        android:paddingStart="20dp"
+        android:paddingEnd="20dp">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:paddingTop="10dp"
+            android:paddingBottom="10dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/split_tunneling_mode_include"
+                android:textColor="@color/nb_txt"
+                android:textSize="16sp" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:text="@string/split_tunneling_mode_include_description"
+                android:textColor="@color/nb_txt_light"
+                android:textSize="12sp" />
+        </LinearLayout>
+
+        <ImageView
+            android:id="@+id/mode_check_include"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_check"
+            android:visibility="invisible"
+            app:tint="@color/nb_orange" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -43,6 +43,12 @@
         tools:layout="@layout/fragment_advanced" />
 
     <fragment
+        android:id="@+id/nav_split_tunneling"
+        android:name="io.netbird.client.ui.splittunneling.SplitTunnelingFragment"
+        android:label="@string/menu_split_tunneling"
+        tools:layout="@layout/fragment_split_tunneling" />
+
+    <fragment
         android:id="@+id/nav_troubleshoot"
         android:name="io.netbird.client.ui.troubleshoot.TroubleshootFragment"
         android:label="@string/menu_troubleshoot"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -300,4 +300,15 @@
         <item quantity="one">Session expires in %1$d day</item>
         <item quantity="other">Session expires in %1$d days</item>
     </plurals>
+    <string name="menu_split_tunneling">Split tunneling</string>
+    <string name="split_tunneling_mode_title">Mode</string>
+    <string name="split_tunneling_mode_off">Off</string>
+    <string name="split_tunneling_mode_off_description">All apps use the VPN</string>
+    <string name="split_tunneling_mode_off_hint">All apps currently use the VPN. Choose a mode to pick which ones do.</string>
+    <string name="split_tunneling_mode_exclude">Exclude</string>
+    <string name="split_tunneling_mode_exclude_description">Selected apps bypass the VPN</string>
+    <string name="split_tunneling_mode_include">Include</string>
+    <string name="split_tunneling_mode_include_description">Only selected apps use the VPN</string>
+    <string name="split_tunneling_hint_search_apps">Search apps</string>
+    <string name="split_tunneling_empty_include_warning">No app selected, so every app keeps using the VPN. Pick at least one.</string>
 </resources>

--- a/tool/src/androidTest/java/io/netbird/client/tool/PreferencesInstrumentedTest.java
+++ b/tool/src/androidTest/java/io/netbird/client/tool/PreferencesInstrumentedTest.java
@@ -11,10 +11,6 @@ import org.junit.runner.RunWith;
 
 import android.content.Context;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-
 @RunWith(AndroidJUnit4.class)
 public class PreferencesInstrumentedTest {
     private static Preferences preferences;
@@ -93,63 +89,5 @@ public class PreferencesInstrumentedTest {
         final var defaultServer = "https://api.netbird.io";
 
         Assert.assertEquals(defaultServer, Preferences.defaultServer());
-    }
-
-    @Test
-    public void shouldDefaultToSplitTunnellingOff() {
-        SplitTunnelConfig config = preferences.getSplitTunnelConfig();
-
-        Assert.assertEquals(SplitTunnelConfig.Mode.OFF, config.getMode());
-        Assert.assertTrue(config.getExcluded().isEmpty());
-        Assert.assertTrue(config.getIncluded().isEmpty());
-    }
-
-    @Test
-    public void shouldRoundTripBothSelectionsAndTheMode() {
-        preferences.saveSplitTunnelConfig(new SplitTunnelConfig(
-                SplitTunnelConfig.Mode.EXCLUDE,
-                new HashSet<>(Arrays.asList("com.example.a", "com.example.b")),
-                new HashSet<>(Collections.singletonList("com.example.c"))));
-
-        SplitTunnelConfig config = preferences.getSplitTunnelConfig();
-
-        Assert.assertEquals(SplitTunnelConfig.Mode.EXCLUDE, config.getMode());
-        Assert.assertEquals(new HashSet<>(Arrays.asList("com.example.a", "com.example.b")),
-                config.getExcluded());
-        Assert.assertEquals(new HashSet<>(Collections.singletonList("com.example.c")),
-                config.getIncluded());
-    }
-
-    // Switching mode must not throw the other list away: the user gets their
-    // previous picks back when they switch back.
-    @Test
-    public void shouldKeepTheInactiveSelectionAcrossAModeChange() {
-        preferences.saveSplitTunnelConfig(new SplitTunnelConfig(
-                SplitTunnelConfig.Mode.EXCLUDE,
-                new HashSet<>(Collections.singletonList("com.example.a")),
-                new HashSet<>(Collections.singletonList("com.example.b"))));
-
-        SplitTunnelConfig stored = preferences.getSplitTunnelConfig();
-        preferences.saveSplitTunnelConfig(new SplitTunnelConfig(
-                SplitTunnelConfig.Mode.INCLUDE, stored.getExcluded(), stored.getIncluded()));
-
-        SplitTunnelConfig config = preferences.getSplitTunnelConfig();
-        Assert.assertEquals(SplitTunnelConfig.Mode.INCLUDE, config.getMode());
-        Assert.assertEquals(new HashSet<>(Collections.singletonList("com.example.a")),
-                config.getExcluded());
-    }
-
-    // A set handed to SharedPreferences is kept by reference and handed back on
-    // read, so a later change to the caller's copy must not leak into storage.
-    @Test
-    public void shouldNotAliasTheCallersSet() {
-        HashSet<String> picks = new HashSet<>(Collections.singletonList("com.example.a"));
-        preferences.saveSplitTunnelConfig(new SplitTunnelConfig(
-                SplitTunnelConfig.Mode.EXCLUDE, picks, Collections.emptySet()));
-
-        picks.add("com.example.late");
-
-        Assert.assertEquals(new HashSet<>(Collections.singletonList("com.example.a")),
-                preferences.getSplitTunnelConfig().getExcluded());
     }
 }

--- a/tool/src/androidTest/java/io/netbird/client/tool/PreferencesInstrumentedTest.java
+++ b/tool/src/androidTest/java/io/netbird/client/tool/PreferencesInstrumentedTest.java
@@ -11,6 +11,10 @@ import org.junit.runner.RunWith;
 
 import android.content.Context;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
 @RunWith(AndroidJUnit4.class)
 public class PreferencesInstrumentedTest {
     private static Preferences preferences;
@@ -89,5 +93,63 @@ public class PreferencesInstrumentedTest {
         final var defaultServer = "https://api.netbird.io";
 
         Assert.assertEquals(defaultServer, Preferences.defaultServer());
+    }
+
+    @Test
+    public void shouldDefaultToSplitTunnellingOff() {
+        SplitTunnelConfig config = preferences.getSplitTunnelConfig();
+
+        Assert.assertEquals(SplitTunnelConfig.Mode.OFF, config.getMode());
+        Assert.assertTrue(config.getExcluded().isEmpty());
+        Assert.assertTrue(config.getIncluded().isEmpty());
+    }
+
+    @Test
+    public void shouldRoundTripBothSelectionsAndTheMode() {
+        preferences.saveSplitTunnelConfig(new SplitTunnelConfig(
+                SplitTunnelConfig.Mode.EXCLUDE,
+                new HashSet<>(Arrays.asList("com.example.a", "com.example.b")),
+                new HashSet<>(Collections.singletonList("com.example.c"))));
+
+        SplitTunnelConfig config = preferences.getSplitTunnelConfig();
+
+        Assert.assertEquals(SplitTunnelConfig.Mode.EXCLUDE, config.getMode());
+        Assert.assertEquals(new HashSet<>(Arrays.asList("com.example.a", "com.example.b")),
+                config.getExcluded());
+        Assert.assertEquals(new HashSet<>(Collections.singletonList("com.example.c")),
+                config.getIncluded());
+    }
+
+    // Switching mode must not throw the other list away: the user gets their
+    // previous picks back when they switch back.
+    @Test
+    public void shouldKeepTheInactiveSelectionAcrossAModeChange() {
+        preferences.saveSplitTunnelConfig(new SplitTunnelConfig(
+                SplitTunnelConfig.Mode.EXCLUDE,
+                new HashSet<>(Collections.singletonList("com.example.a")),
+                new HashSet<>(Collections.singletonList("com.example.b"))));
+
+        SplitTunnelConfig stored = preferences.getSplitTunnelConfig();
+        preferences.saveSplitTunnelConfig(new SplitTunnelConfig(
+                SplitTunnelConfig.Mode.INCLUDE, stored.getExcluded(), stored.getIncluded()));
+
+        SplitTunnelConfig config = preferences.getSplitTunnelConfig();
+        Assert.assertEquals(SplitTunnelConfig.Mode.INCLUDE, config.getMode());
+        Assert.assertEquals(new HashSet<>(Collections.singletonList("com.example.a")),
+                config.getExcluded());
+    }
+
+    // A set handed to SharedPreferences is kept by reference and handed back on
+    // read, so a later change to the caller's copy must not leak into storage.
+    @Test
+    public void shouldNotAliasTheCallersSet() {
+        HashSet<String> picks = new HashSet<>(Collections.singletonList("com.example.a"));
+        preferences.saveSplitTunnelConfig(new SplitTunnelConfig(
+                SplitTunnelConfig.Mode.EXCLUDE, picks, Collections.emptySet()));
+
+        picks.add("com.example.late");
+
+        Assert.assertEquals(new HashSet<>(Collections.singletonList("com.example.a")),
+                preferences.getSplitTunnelConfig().getExcluded());
     }
 }

--- a/tool/src/main/java/io/netbird/client/tool/IFace.java
+++ b/tool/src/main/java/io/netbird/client/tool/IFace.java
@@ -140,11 +140,12 @@ class IFace implements TunAdapter {
      *
      * The selection is read here rather than passed in because the tunnel is
      * also rebuilt from VPNService without going through the Go engine, and both
-     * paths must see the same stored answer.
+     * paths must see the same stored answer. It belongs to the active profile,
+     * so switching profile switches which applications the tunnel carries.
      */
     private void applyAppFilter(VpnService.Builder builder) {
-        SplitTunnelConfig.Resolution resolution = new Preferences(vpnService)
-                .getSplitTunnelConfig()
+        SplitTunnelConfig.Resolution resolution = new SplitTunnelStore(vpnService)
+                .load()
                 .resolve(vpnService.getPackageName());
 
         boolean allow = resolution.getFilter() == SplitTunnelConfig.Filter.ALLOW;

--- a/tool/src/main/java/io/netbird/client/tool/IFace.java
+++ b/tool/src/main/java/io/netbird/client/tool/IFace.java
@@ -86,10 +86,7 @@ class IFace implements TunAdapter {
             Log.d(LOGTAG, "add route: "+r.addr+"/"+r.prefixLength);
         }
 
-        disallowApp(builder, "com.google.android.projection.gearhead");
-        disallowApp(builder, "com.google.android.apps.chromecast.app");
-        disallowApp(builder, "com.google.android.apps.messaging");
-        disallowApp(builder, "com.google.stadia.android");
+        applyAppFilter(builder);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             builder.setMetered(false);
@@ -138,11 +135,35 @@ class IFace implements TunAdapter {
         }
     }
 
-    private void disallowApp(VpnService.Builder builder, String packageName) {
-        try {
-            builder.addDisallowedApplication(packageName);
-        } catch (PackageManager.NameNotFoundException ignored) {
+    /**
+     * Narrows the tunnel to the apps the user picked.
+     *
+     * The selection is read here rather than passed in because the tunnel is
+     * also rebuilt from VPNService without going through the Go engine, and both
+     * paths must see the same stored answer.
+     */
+    private void applyAppFilter(VpnService.Builder builder) {
+        SplitTunnelConfig.Resolution resolution = new Preferences(vpnService)
+                .getSplitTunnelConfig()
+                .resolve(vpnService.getPackageName());
+
+        boolean allow = resolution.getFilter() == SplitTunnelConfig.Filter.ALLOW;
+        for (String packageName : resolution.getPackages()) {
+            try {
+                if (allow) {
+                    builder.addAllowedApplication(packageName);
+                } else {
+                    builder.addDisallowedApplication(packageName);
+                }
+            } catch (PackageManager.NameNotFoundException ignored) {
+                // Uninstalled since it was picked. Dropping the whole tunnel over a
+                // stale entry would be worse than ignoring it; the list screen
+                // prunes it on the next visit.
+            }
         }
+
+        Log.d(LOGTAG, "app filter: " + (allow ? "allow " : "disallow ")
+                + resolution.getPackages().size() + " package(s)");
     }
 
     @SuppressLint("DefaultLocale")

--- a/tool/src/main/java/io/netbird/client/tool/Preferences.java
+++ b/tool/src/main/java/io/netbird/client/tool/Preferences.java
@@ -3,20 +3,11 @@ package io.netbird.client.tool;
 import android.content.Context;
 import android.content.SharedPreferences;
 
-import java.util.Collections;
-import java.util.Set;
-
 public class Preferences {
 
     private final String keyTraceLog = "tracelog";
 
     private final String keyForceRelayConnection = "isConnectionForceRelayed";
-
-    private final String keySplitTunnelMode = "splitTunnelMode";
-
-    private final String keySplitTunnelExcluded = "splitTunnelExcluded";
-
-    private final String keySplitTunnelIncluded = "splitTunnelIncluded";
 
     private final SharedPreferences sharedPref;
 
@@ -45,42 +36,6 @@ public class Preferences {
 
     public void disableForcedRelayConnection() {
         sharedPref.edit().putBoolean(keyForceRelayConnection, false).apply();
-    }
-
-    public SplitTunnelConfig getSplitTunnelConfig() {
-        return new SplitTunnelConfig(
-                readMode(),
-                sharedPref.getStringSet(keySplitTunnelExcluded, Collections.emptySet()),
-                sharedPref.getStringSet(keySplitTunnelIncluded, Collections.emptySet()));
-    }
-
-    /**
-     * Written in one commit so the mode and the selection it refers to can never
-     * be read half-updated by the service while it rebuilds the tunnel.
-     */
-    public void saveSplitTunnelConfig(SplitTunnelConfig config) {
-        sharedPref.edit()
-                .putString(keySplitTunnelMode, config.getMode().name())
-                .putStringSet(keySplitTunnelExcluded, copyForStorage(config.getExcluded()))
-                .putStringSet(keySplitTunnelIncluded, copyForStorage(config.getIncluded()))
-                .apply();
-    }
-
-    private SplitTunnelConfig.Mode readMode() {
-        String stored = sharedPref.getString(keySplitTunnelMode, SplitTunnelConfig.Mode.OFF.name());
-        try {
-            return SplitTunnelConfig.Mode.valueOf(stored);
-        } catch (IllegalArgumentException e) {
-            // A mode written by a newer build, or a corrupted value: fall back to
-            // carrying everything rather than dropping traffic on the floor.
-            return SplitTunnelConfig.Mode.OFF;
-        }
-    }
-
-    // SharedPreferences keeps a reference to the set it is handed and returns it
-    // again on read, so it must not be one the caller can still mutate.
-    private static Set<String> copyForStorage(Set<String> packages) {
-        return new java.util.HashSet<>(packages);
     }
 
     public static String defaultServer() {

--- a/tool/src/main/java/io/netbird/client/tool/Preferences.java
+++ b/tool/src/main/java/io/netbird/client/tool/Preferences.java
@@ -3,11 +3,20 @@ package io.netbird.client.tool;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import java.util.Collections;
+import java.util.Set;
+
 public class Preferences {
 
     private final String keyTraceLog = "tracelog";
 
     private final String keyForceRelayConnection = "isConnectionForceRelayed";
+
+    private final String keySplitTunnelMode = "splitTunnelMode";
+
+    private final String keySplitTunnelExcluded = "splitTunnelExcluded";
+
+    private final String keySplitTunnelIncluded = "splitTunnelIncluded";
 
     private final SharedPreferences sharedPref;
 
@@ -36,6 +45,42 @@ public class Preferences {
 
     public void disableForcedRelayConnection() {
         sharedPref.edit().putBoolean(keyForceRelayConnection, false).apply();
+    }
+
+    public SplitTunnelConfig getSplitTunnelConfig() {
+        return new SplitTunnelConfig(
+                readMode(),
+                sharedPref.getStringSet(keySplitTunnelExcluded, Collections.emptySet()),
+                sharedPref.getStringSet(keySplitTunnelIncluded, Collections.emptySet()));
+    }
+
+    /**
+     * Written in one commit so the mode and the selection it refers to can never
+     * be read half-updated by the service while it rebuilds the tunnel.
+     */
+    public void saveSplitTunnelConfig(SplitTunnelConfig config) {
+        sharedPref.edit()
+                .putString(keySplitTunnelMode, config.getMode().name())
+                .putStringSet(keySplitTunnelExcluded, copyForStorage(config.getExcluded()))
+                .putStringSet(keySplitTunnelIncluded, copyForStorage(config.getIncluded()))
+                .apply();
+    }
+
+    private SplitTunnelConfig.Mode readMode() {
+        String stored = sharedPref.getString(keySplitTunnelMode, SplitTunnelConfig.Mode.OFF.name());
+        try {
+            return SplitTunnelConfig.Mode.valueOf(stored);
+        } catch (IllegalArgumentException e) {
+            // A mode written by a newer build, or a corrupted value: fall back to
+            // carrying everything rather than dropping traffic on the floor.
+            return SplitTunnelConfig.Mode.OFF;
+        }
+    }
+
+    // SharedPreferences keeps a reference to the set it is handed and returns it
+    // again on read, so it must not be one the caller can still mutate.
+    private static Set<String> copyForStorage(Set<String> packages) {
+        return new java.util.HashSet<>(packages);
     }
 
     public static String defaultServer() {

--- a/tool/src/main/java/io/netbird/client/tool/SplitTunnelConfig.java
+++ b/tool/src/main/java/io/netbird/client/tool/SplitTunnelConfig.java
@@ -1,0 +1,134 @@
+package io.netbird.client.tool;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Which applications the tunnel carries.
+ *
+ * Android lets a VpnService name either the apps that stay out of the tunnel or
+ * the apps that are the only ones in it, never both on the same builder, so the
+ * two selections are kept apart and a mode says which one is live.
+ *
+ * Deliberately free of Android types: the rules below are the part worth testing
+ * on the JVM, away from a device.
+ */
+public final class SplitTunnelConfig {
+
+    public enum Mode {
+        /** Everything but {@link #ALWAYS_EXCLUDED} goes through the tunnel. */
+        OFF,
+        /** The user's picks stay out of the tunnel; everything else goes in. */
+        EXCLUDE,
+        /** Only the user's picks go through the tunnel. */
+        INCLUDE
+    }
+
+    /** How the resolved packages are meant to be handed to VpnService.Builder. */
+    public enum Filter {
+        DISALLOW,
+        ALLOW
+    }
+
+    /**
+     * Apps that misbehave when tunnelled, kept out in every mode that can express
+     * an exclusion. They predate this feature and stay as the floor of EXCLUDE so
+     * that turning split tunnelling on never silently pulls them into the tunnel.
+     */
+    public static final Set<String> ALWAYS_EXCLUDED = Collections.unmodifiableSet(
+            new LinkedHashSet<>(java.util.Arrays.asList(
+                    "com.google.android.projection.gearhead",
+                    "com.google.android.apps.chromecast.app",
+                    "com.google.android.apps.messaging",
+                    "com.google.stadia.android")));
+
+    private final Mode mode;
+    private final Set<String> excluded;
+    private final Set<String> included;
+
+    public SplitTunnelConfig(Mode mode, Collection<String> excluded, Collection<String> included) {
+        this.mode = mode == null ? Mode.OFF : mode;
+        this.excluded = copyOf(excluded);
+        this.included = copyOf(included);
+    }
+
+    public Mode getMode() {
+        return mode;
+    }
+
+    public Set<String> getExcluded() {
+        return excluded;
+    }
+
+    public Set<String> getIncluded() {
+        return included;
+    }
+
+    /**
+     * An INCLUDE selection that is empty would allow no app at all, leaving a
+     * tunnel that carries nothing and looks broken rather than configured. Such a
+     * config is reported as inactive and resolves like {@link Mode#OFF}, so the UI
+     * can warn about it with the same answer the tunnel will act on.
+     */
+    public boolean isActive() {
+        if (mode == Mode.EXCLUDE) {
+            return !excluded.isEmpty();
+        }
+        if (mode == Mode.INCLUDE) {
+            return !included.isEmpty();
+        }
+        return false;
+    }
+
+    /**
+     * @param ownPackage this app's own package name, always allowed in INCLUDE
+     *                   mode: the Go engine's own sockets bypass the tunnel via
+     *                   protectSocket, but the built-in SSH client has to reach
+     *                   peers through it.
+     */
+    public Resolution resolve(String ownPackage) {
+        if (mode == Mode.INCLUDE && isActive()) {
+            Set<String> allowed = new LinkedHashSet<>(included);
+            if (ownPackage != null && !ownPackage.isEmpty()) {
+                allowed.add(ownPackage);
+            }
+            return new Resolution(Filter.ALLOW, allowed);
+        }
+
+        Set<String> disallowed = new LinkedHashSet<>(ALWAYS_EXCLUDED);
+        if (mode == Mode.EXCLUDE) {
+            disallowed.addAll(excluded);
+        }
+        return new Resolution(Filter.DISALLOW, disallowed);
+    }
+
+    private static Set<String> copyOf(Collection<String> source) {
+        if (source == null || source.isEmpty()) {
+            return Collections.emptySet();
+        }
+        // SharedPreferences hands back a set that must not be touched, and the
+        // caller may keep mutating its own; copy on the way in.
+        return Collections.unmodifiableSet(new LinkedHashSet<>(source));
+    }
+
+    /** The packages to apply, and the builder method to apply them with. */
+    public static final class Resolution {
+        private final Filter filter;
+        private final Set<String> packages;
+
+        Resolution(Filter filter, Set<String> packages) {
+            this.filter = filter;
+            this.packages = Collections.unmodifiableSet(packages);
+        }
+
+        public Filter getFilter() {
+            return filter;
+        }
+
+        public Set<String> getPackages() {
+            return packages;
+        }
+    }
+}

--- a/tool/src/main/java/io/netbird/client/tool/SplitTunnelStore.java
+++ b/tool/src/main/java/io/netbird/client/tool/SplitTunnelStore.java
@@ -1,0 +1,104 @@
+package io.netbird.client.tool;
+
+import android.content.Context;
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.netbird.gomobile.android.Android;
+import io.netbird.gomobile.android.PackageList;
+import io.netbird.gomobile.android.SplitTunnelSettings;
+
+/**
+ * The split tunnelling selection of the active profile.
+ *
+ * The settings belong to a profile and are kept on the Go side with the rest of
+ * a profile's preferences, so switching profile switches which applications the
+ * tunnel carries. This class is only the translation layer: which packages end
+ * up on the interface, and how, stays in {@link SplitTunnelConfig}.
+ */
+public class SplitTunnelStore {
+
+    private static final String LOGTAG = "SplitTunnelStore";
+
+    private final String configDir;
+    private final ProfileManagerWrapper profileManager;
+
+    public SplitTunnelStore(Context context) {
+        this.configDir = context.getFilesDir().getPath();
+        this.profileManager = new ProfileManagerWrapper(context);
+    }
+
+    /**
+     * Reads the active profile's selection. A profile that has never stored one,
+     * an unreadable store, or no active profile all mean the same thing to the
+     * caller: carry every application.
+     */
+    public SplitTunnelConfig load() {
+        try {
+            SplitTunnelSettings settings = openStore().load();
+            return new SplitTunnelConfig(
+                    toMode(settings.getMode()),
+                    toList(settings.getExcluded()),
+                    toList(settings.getIncluded()));
+        } catch (Exception e) {
+            Log.w(LOGTAG, "could not read the split tunnelling settings", e);
+            return new SplitTunnelConfig(SplitTunnelConfig.Mode.OFF, null, null);
+        }
+    }
+
+    public void save(SplitTunnelConfig config) throws Exception {
+        SplitTunnelSettings settings = Android.newSplitTunnelSettings();
+        settings.setMode(toGoMode(config.getMode()));
+        fill(settings.getExcluded(), config.getExcluded());
+        fill(settings.getIncluded(), config.getIncluded());
+        openStore().save(settings);
+    }
+
+    private io.netbird.gomobile.android.SplitTunnelStore openStore() throws Exception {
+        Profile active = profileManager.getActiveProfile();
+        if (active == null) {
+            throw new IllegalStateException("no active profile");
+        }
+        return Android.newSplitTunnelStore(configDir, active.getID());
+    }
+
+    private static void fill(PackageList target, Iterable<String> packages) {
+        for (String packageName : packages) {
+            target.add(packageName);
+        }
+    }
+
+    private static List<String> toList(PackageList list) {
+        List<String> out = new ArrayList<>();
+        if (list == null) {
+            return out;
+        }
+        for (int i = 0; i < list.size(); i++) {
+            out.add(list.get(i));
+        }
+        return out;
+    }
+
+    private static SplitTunnelConfig.Mode toMode(String goMode) {
+        if (Android.SplitTunnelModeExclude.equals(goMode)) {
+            return SplitTunnelConfig.Mode.EXCLUDE;
+        }
+        if (Android.SplitTunnelModeInclude.equals(goMode)) {
+            return SplitTunnelConfig.Mode.INCLUDE;
+        }
+        return SplitTunnelConfig.Mode.OFF;
+    }
+
+    private static String toGoMode(SplitTunnelConfig.Mode mode) {
+        switch (mode) {
+            case EXCLUDE:
+                return Android.SplitTunnelModeExclude;
+            case INCLUDE:
+                return Android.SplitTunnelModeInclude;
+            default:
+                return Android.SplitTunnelModeOff;
+        }
+    }
+}

--- a/tool/src/main/java/io/netbird/client/tool/SplitTunnelStore.java
+++ b/tool/src/main/java/io/netbird/client/tool/SplitTunnelStore.java
@@ -81,17 +81,17 @@ public class SplitTunnelStore {
         return out;
     }
 
-    private static SplitTunnelConfig.Mode toMode(String goMode) {
-        if (Android.SplitTunnelModeExclude.equals(goMode)) {
+    private static SplitTunnelConfig.Mode toMode(long goMode) {
+        if (goMode == Android.SplitTunnelModeExclude) {
             return SplitTunnelConfig.Mode.EXCLUDE;
         }
-        if (Android.SplitTunnelModeInclude.equals(goMode)) {
+        if (goMode == Android.SplitTunnelModeInclude) {
             return SplitTunnelConfig.Mode.INCLUDE;
         }
         return SplitTunnelConfig.Mode.OFF;
     }
 
-    private static String toGoMode(SplitTunnelConfig.Mode mode) {
+    private static long toGoMode(SplitTunnelConfig.Mode mode) {
         switch (mode) {
             case EXCLUDE:
                 return Android.SplitTunnelModeExclude;

--- a/tool/src/main/java/io/netbird/client/tool/TUNCreatorLooperThread.java
+++ b/tool/src/main/java/io/netbird/client/tool/TUNCreatorLooperThread.java
@@ -7,14 +7,25 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 public class TUNCreatorLooperThread extends Thread {
     private static final String TAG = TUNCreatorLooperThread.class.getSimpleName();
+
+    /** what value of the message asking for the TUN to be rebuilt. */
+    public static final int MSG_RENEW_TUN = 1;
+
+    /**
+     * arg1 value asking for the rebuild to happen even when the engine reports
+     * the same routes and search domains as before.
+     */
+    public static final int ARG_FORCE = 1;
+
     private Handler handler;
 
-    private final Runnable tunCreator;
+    private final Consumer<Boolean> tunCreator;
 
-    public TUNCreatorLooperThread(Runnable tunCreator) {
+    public TUNCreatorLooperThread(Consumer<Boolean> tunCreator) {
         this.tunCreator = tunCreator;
     }
 
@@ -25,9 +36,10 @@ public class TUNCreatorLooperThread extends Thread {
             handler = new Handler(Objects.requireNonNull(Looper.myLooper())) {
                 @Override
                 public void handleMessage(@NonNull Message msg) {
-                    if (msg.what == 1) {
-                        Log.d(TAG, "handleMessage: renewing TUN!");
-                        tunCreator.run();
+                    if (msg.what == MSG_RENEW_TUN) {
+                        boolean force = msg.arg1 == ARG_FORCE;
+                        Log.d(TAG, "handleMessage: renewing TUN!" + (force ? " (forced)" : ""));
+                        tunCreator.accept(force);
                     }
                 }
             };

--- a/tool/src/main/java/io/netbird/client/tool/VPNService.java
+++ b/tool/src/main/java/io/netbird/client/tool/VPNService.java
@@ -333,6 +333,15 @@ public class VPNService extends android.net.VpnService {
             return engineRunner.debugBundle(anonymize);
         }
 
+        /**
+         * Rebuilds the tunnel so a split tunnelling change takes hold without
+         * asking the user to disconnect. A no-op while the engine is down: the
+         * new selection is read when the tunnel is next created.
+         */
+        public void applySplitTunneling() {
+            queueTUNRenewal(true);
+        }
+
         public void selectRoute(String route) throws Exception {
             engineRunner.selectRoute(route);
         }
@@ -502,19 +511,24 @@ public class VPNService extends android.net.VpnService {
     private TUNCreatorLooperThread tunCreator;
 
     private void queueTUNRenewal(String ignoredPayload) {
+        queueTUNRenewal(false);
+    }
+
+    private void queueTUNRenewal(boolean force) {
         if (tunCreator == null) {
             tunCreator = new TUNCreatorLooperThread(this::recreateTUN);
             tunCreator.setPriority(Thread.MAX_PRIORITY);
             tunCreator.start();
         }
 
-        var message = tunCreator.getHandler().obtainMessage(1);
+        var message = tunCreator.getHandler().obtainMessage(TUNCreatorLooperThread.MSG_RENEW_TUN);
+        message.arg1 = force ? TUNCreatorLooperThread.ARG_FORCE : 0;
         boolean isQueued = tunCreator.getHandler().sendMessage(message);
 
-        Log.d(LOGTAG, String.format("is TUN renewal queued? %b", isQueued));
+        Log.d(LOGTAG, String.format("is TUN renewal queued? %b (forced: %b)", isQueued, force));
     }
 
-    private void recreateTUN() {
+    private void recreateTUN(boolean force) {
         if (!engineRunner.isRunning()) return;
         if (currentTUNParameters == null) return;
 
@@ -525,7 +539,9 @@ public class VPNService extends android.net.VpnService {
 
         String routes = settings.getRoutes();
         String searchDomains = settings.getSearchDomains();
-        if (!currentTUNParameters.didChange(routes, searchDomains)) {
+        // A changed app filter leaves routes and search domains untouched, so the
+        // usual guard would skip the very rebuild that applies it.
+        if (!force && !currentTUNParameters.didChange(routes, searchDomains)) {
             return;
         }
 

--- a/tool/src/test/java/io/netbird/client/tool/SplitTunnelConfigUnitTest.java
+++ b/tool/src/test/java/io/netbird/client/tool/SplitTunnelConfigUnitTest.java
@@ -1,0 +1,138 @@
+package io.netbird.client.tool;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class SplitTunnelConfigUnitTest {
+
+    private static final String OWN = "io.netbird.client";
+
+    private static SplitTunnelConfig config(SplitTunnelConfig.Mode mode,
+                                            Set<String> excluded,
+                                            Set<String> included) {
+        return new SplitTunnelConfig(mode, excluded, included);
+    }
+
+    private static Set<String> setOf(String... values) {
+        return new HashSet<>(Arrays.asList(values));
+    }
+
+    @Test
+    public void offKeepsOnlyTheHistoricExclusions() {
+        SplitTunnelConfig.Resolution r =
+                config(SplitTunnelConfig.Mode.OFF, Collections.emptySet(), Collections.emptySet())
+                        .resolve(OWN);
+
+        assertEquals(SplitTunnelConfig.Filter.DISALLOW, r.getFilter());
+        assertEquals(SplitTunnelConfig.ALWAYS_EXCLUDED, r.getPackages());
+    }
+
+    @Test
+    public void offIgnoresSelectionsMadeInEitherMode() {
+        SplitTunnelConfig.Resolution r =
+                config(SplitTunnelConfig.Mode.OFF, setOf("com.example.a"), setOf("com.example.b"))
+                        .resolve(OWN);
+
+        assertEquals(SplitTunnelConfig.ALWAYS_EXCLUDED, r.getPackages());
+    }
+
+    @Test
+    public void excludeAddsThePicksOnTopOfTheHistoricOnes() {
+        SplitTunnelConfig.Resolution r =
+                config(SplitTunnelConfig.Mode.EXCLUDE, setOf("com.example.a"), Collections.emptySet())
+                        .resolve(OWN);
+
+        assertEquals(SplitTunnelConfig.Filter.DISALLOW, r.getFilter());
+        assertTrue(r.getPackages().containsAll(SplitTunnelConfig.ALWAYS_EXCLUDED));
+        assertTrue(r.getPackages().contains("com.example.a"));
+    }
+
+    @Test
+    public void includeAllowsOnlyThePicksPlusThisApp() {
+        SplitTunnelConfig.Resolution r =
+                config(SplitTunnelConfig.Mode.INCLUDE, Collections.emptySet(), setOf("com.example.a"))
+                        .resolve(OWN);
+
+        assertEquals(SplitTunnelConfig.Filter.ALLOW, r.getFilter());
+        assertEquals(setOf("com.example.a", OWN), r.getPackages());
+    }
+
+    // The built-in SSH client has to reach peers through the tunnel, so the app
+    // must never be able to lock itself out of it.
+    @Test
+    public void includeAlwaysCarriesThisApp() {
+        SplitTunnelConfig.Resolution r =
+                config(SplitTunnelConfig.Mode.INCLUDE, Collections.emptySet(), setOf("com.example.a"))
+                        .resolve(OWN);
+
+        assertTrue(r.getPackages().contains(OWN));
+    }
+
+    // An empty allowlist would leave a tunnel carrying nothing, which reads as a
+    // broken VPN rather than a configured one.
+    @Test
+    public void emptyIncludeFallsBackToCarryingEverything() {
+        SplitTunnelConfig cfg =
+                config(SplitTunnelConfig.Mode.INCLUDE, Collections.emptySet(), Collections.emptySet());
+
+        assertFalse(cfg.isActive());
+        SplitTunnelConfig.Resolution r = cfg.resolve(OWN);
+        assertEquals(SplitTunnelConfig.Filter.DISALLOW, r.getFilter());
+        assertEquals(SplitTunnelConfig.ALWAYS_EXCLUDED, r.getPackages());
+    }
+
+    @Test
+    public void emptyExcludeIsInactiveButStillDropsTheHistoricOnes() {
+        SplitTunnelConfig cfg =
+                config(SplitTunnelConfig.Mode.EXCLUDE, Collections.emptySet(), Collections.emptySet());
+
+        assertFalse(cfg.isActive());
+        assertEquals(SplitTunnelConfig.ALWAYS_EXCLUDED, cfg.resolve(OWN).getPackages());
+    }
+
+    @Test
+    public void selectionsAreActiveWhenNotEmpty() {
+        assertTrue(config(SplitTunnelConfig.Mode.EXCLUDE, setOf("com.example.a"), Collections.emptySet()).isActive());
+        assertTrue(config(SplitTunnelConfig.Mode.INCLUDE, Collections.emptySet(), setOf("com.example.a")).isActive());
+    }
+
+    @Test
+    public void nullModeAndNullSelectionsAreTreatedAsOff() {
+        SplitTunnelConfig cfg = new SplitTunnelConfig(null, null, null);
+
+        assertEquals(SplitTunnelConfig.Mode.OFF, cfg.getMode());
+        assertTrue(cfg.getExcluded().isEmpty());
+        assertTrue(cfg.getIncluded().isEmpty());
+        assertEquals(SplitTunnelConfig.ALWAYS_EXCLUDED, cfg.resolve(OWN).getPackages());
+    }
+
+    // SharedPreferences hands back a set it keeps using, so the config must not
+    // hold on to anything the caller can still change underneath it.
+    @Test
+    public void storedSelectionIsCopiedNotAliased() {
+        Set<String> mutable = setOf("com.example.a");
+        SplitTunnelConfig cfg = config(SplitTunnelConfig.Mode.EXCLUDE, mutable, Collections.emptySet());
+
+        mutable.add("com.example.late");
+
+        assertFalse(cfg.getExcluded().contains("com.example.late"));
+        assertFalse(cfg.resolve(OWN).getPackages().contains("com.example.late"));
+    }
+
+    @Test
+    public void resolutionWithoutOwnPackageStillWorks() {
+        SplitTunnelConfig.Resolution r =
+                config(SplitTunnelConfig.Mode.INCLUDE, Collections.emptySet(), setOf("com.example.a"))
+                        .resolve(null);
+
+        assertEquals(setOf("com.example.a"), r.getPackages());
+    }
+}


### PR DESCRIPTION
# Let the user choose which apps the tunnel carries

## What

Adds a split tunnelling screen under Settings, letting the user decide which
applications the tunnel carries. Three modes:

- **Off** — every app uses the VPN, the current behaviour.
- **Exclude** — the picked apps bypass the tunnel, everything else stays in it.
- **Include** — only the picked apps use the tunnel.

Until now `IFace.createTun` kept four applications out of the tunnel with no way
for the user to add their own. Those four remain the floor of Exclude, so
turning split tunnelling on never silently pulls them back in.

## How

Android's `VpnService.Builder` takes an allow list or a deny list, never both on
the same builder, so the two selections are stored apart and a mode says which
one is live. `SplitTunnelConfig` holds that decision — plain Java, no Android
types, so the rules are covered by JVM unit tests.

A change to the selection leaves routes and search domains untouched, which the
existing `recreateTUN` guard reads as "nothing to do". The renewal request now
carries a force flag so the rebuild that applies the new filter actually runs,
and the change takes hold without asking the user to reconnect.

Two rules are worth calling out:

- An empty Include selection would allow no app at all, leaving a tunnel that
  carries nothing and reads as broken rather than configured. It falls back to
  carrying everything, and the screen says so.
- Include always carries this app. The Go engine's own sockets bypass the tunnel
  through `protectSocket`, but the built-in SSH client has to reach peers
  through it.

The app list resolves the launcher intent rather than asking for
`QUERY_ALL_PACKAGES`, which Play treats as a sensitive permission. The trade-off
is that applications without a launcher entry are not listed.

## Tests

- `SplitTunnelConfigUnitTest` — 11 JVM tests covering mode resolution, the empty
  allowlist fallback, self-inclusion, and defensive copying of the stored sets.
- `PreferencesInstrumentedTest` — 4 new cases for persistence, including keeping
  the inactive selection across a mode change.

Verified by hand on an API 30 emulator with the tunnel up, watching the filter
follow the mode (`disallow 4` → `disallow 5` → `allow 2`) and the tunnel rebuild
on every change without a reconnection.

## Screenshots

| Settings entry | Mode picker |
|---|---|
| <img src="https://github.com/user-attachments/assets/0842a772-8296-4011-a335-3eb034b31bb6" width="250"> | <img src="https://github.com/user-attachments/assets/7c4d37ef-d7bb-4c25-a687-f77292505bd4" width="250"> |

| Exclude mode | Empty allowlist |
|---|---|
| <img src="https://github.com/user-attachments/assets/479b8044-476d-4acb-8b08-224edbc27feb" width="250"> | <img src="https://github.com/user-attachments/assets/b0a5b083-4e30-4870-80bc-ec501230329f" width="250"> |

## Note for reviewers

The branch also carries `Implement the ConnectionListener state callback`, kept
as a separate commit. The netbird bump in `1b7f067` added `OnStateChanged` to the
interface without the Java side following, which leaves the branch unable to
compile. Drop that commit if it lands upstream first.
