### PR TITLE
Stop Android's local network protection from blocking overlay traffic

### DIFF
--- a/tool/src/main/java/io/netbird/client/tool/IFace.java
+++ b/tool/src/main/java/io/netbird/client/tool/IFace.java
@@ -11,16 +11,21 @@ import android.os.ParcelFileDescriptor;
 import android.system.OsConstants;
 import android.util.Log;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.LinkedList;
 import java.util.concurrent.CountDownLatch;
 
 import io.netbird.gomobile.android.TunAdapter;
 import io.netbird.client.tool.wg.BackendException;
+import io.netbird.client.tool.wg.InetAddresses;
 import io.netbird.client.tool.wg.InetNetwork;
 
 class IFace implements TunAdapter {
 
     private static final String LOGTAG = "IFace";
+    private static final int HOST_PREFIX_V4 = 32;
+    private static final int HOST_PREFIX_V6 = 128;
     private final VPNService vpnService;
 
     public IFace(VPNService vpnService) {
@@ -63,9 +68,20 @@ class IFace implements TunAdapter {
 
     private int createTun(String ip, int prefixLength, InetNetwork addrV6, int mtu, String dns, String[] searchDomains, LinkedList<Route> routes) throws Exception {
         VpnService.Builder builder = vpnService.getBuilder();
-        builder.addAddress(ip, prefixLength);
+
+        // Assign the overlay addresses as single hosts and express the overlay
+        // network as an explicit route instead of letting it fall out of the
+        // address prefix. A prefix wider than a single host makes the tunnel a
+        // directly connected, broadcast-capable subnet, which is one of the
+        // things Android's local network protection keys on when deciding
+        // whether an app needs ACCESS_LOCAL_NETWORK to reach a destination.
+        // Reachability is unchanged: the route below covers exactly the range
+        // the address prefix used to cover.
+        builder.addAddress(ip, HOST_PREFIX_V4);
+        addNetworkRoute(builder, InetAddresses.parse(ip), prefixLength);
         if (addrV6 != null) {
-            builder.addAddress(addrV6.getAddress().getHostAddress(), addrV6.getMask());
+            builder.addAddress(addrV6.getAddress().getHostAddress(), HOST_PREFIX_V6);
+            addNetworkRoute(builder, addrV6.getAddress(), addrV6.getMask());
             Log.d(LOGTAG, "add IPv6 address: " + addrV6.getAddress().getHostAddress() + "/" + addrV6.getMask());
         }
         builder.allowFamily(OsConstants.AF_INET);
@@ -136,6 +152,39 @@ class IFace implements TunAdapter {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
+    }
+
+    /**
+     * Adds the route covering the overlay network the given address belongs to.
+     * No-op for an address that is already a single host, and for a malformed
+     * prefix, where dropping the route is safer than throwing away the whole
+     * tunnel.
+     */
+    private void addNetworkRoute(VpnService.Builder builder, InetAddress address, int prefixLength) {
+        byte[] raw = address.getAddress();
+        if (prefixLength <= 0 || prefixLength >= raw.length * 8) {
+            return;
+        }
+
+        byte[] masked = maskAddress(raw, prefixLength);
+        try {
+            String network = InetAddress.getByAddress(masked).getHostAddress();
+            builder.addRoute(network, prefixLength);
+            Log.d(LOGTAG, "add overlay network route: " + network + "/" + prefixLength);
+        } catch (UnknownHostException e) {
+            Log.e(LOGTAG, "failed to derive the overlay network route", e);
+        }
+    }
+
+    /** Clears every host bit beyond prefixLength, returning the network address. */
+    private static byte[] maskAddress(byte[] raw, int prefixLength) {
+        byte[] masked = raw.clone();
+        for (int i = 0; i < masked.length; i++) {
+            int bitsKeptInThisByte = Math.min(8, Math.max(0, prefixLength - i * 8));
+            int mask = bitsKeptInThisByte == 0 ? 0 : (0xFF << (8 - bitsKeptInThisByte)) & 0xFF;
+            masked[i] = (byte) (masked[i] & mask);
+        }
+        return masked;
     }
 
     private void disallowApp(VpnService.Builder builder, String packageName) {


### PR DESCRIPTION
## Problem

On Android 16 and later, apps other than the NetBird client itself cannot reach
the overlay network or the networks routed through it, while the client reports
everything as connected and the engine forwards traffic normally.

The failure looks like two unrelated bugs, which is what makes it hard to place:

- ICMP and UDP fail immediately with `EPERM` — `ping <overlay peer>` returns
  `Operation not permitted` before a packet is sent.
- TCP hangs until it times out with no error — `ssh` and `curl` to the same
  peer produce no output at all.

Traffic from `adb shell` works throughout, and so does traffic from apps that
happen to hold the permission described below, so the tunnel itself looks
healthy and the problem reads as a NetBird routing or ACL issue. It is neither.

## Cause

Android 16 introduced [local network protection][lnp]. Reaching a destination
classified as local network now requires `ACCESS_LOCAL_NETWORK`, and the
platform enforces it exactly the way the two symptoms above describe: `EPERM`
for connectionless traffic, a silent drop for TCP.

`IFace.createTun` passed the overlay prefix straight to
`VpnService.Builder.addAddress`:

```java
builder.addAddress(ip, prefixLength);   // e.g. 100.91.96.107/16
```

A prefix wider than a single host makes the tunnel a directly connected,
broadcast-capable subnet. On the device this is visible as a kernel-scope link
route covering the whole overlay plus a broadcast address:

```
100.91.0.0/16 dev tun1 proto kernel scope link src 100.91.21.162
broadcast 100.91.255.255 dev tun1 table local proto kernel scope link
```

Directly connected routes and broadcast-capable interfaces are among the
signals the local-network classification uses. The whole overlay is therefore
treated as local network — and so are the RFC1918 ranges routed through the
tunnel, which fall in the restricted ranges on their own. Every app that does
not hold `ACCESS_LOCAL_NETWORK` loses access to all of it.

There is no workaround on the app side for many of the affected apps: a
permission that an app does not declare in its manifest cannot be granted to
it, not even with `pm grant`. Termux, for instance, targets API 37 and does not
declare it.

For comparison, Tailscale assigns its node address as a `/32` and adds
`100.64.0.0/10` as an ordinary route, which produces no connected subnet and no
broadcast address.

[lnp]: https://developer.android.com/privacy-and-security/local-network-permission

## Fix

Assign the tunnel addresses as single hosts (`/32` and `/128`) and express the
overlay network as an ordinary route instead of letting it fall out of the
address prefix:

```java
builder.addAddress(ip, HOST_PREFIX_V4);
addNetworkRoute(builder, InetAddresses.parse(ip), prefixLength);
```

The set of reachable destinations is identical — the route added covers exactly
the range the address prefix used to cover — and only the on-link
classification changes. `addNetworkRoute` is deliberately belt-and-braces: the
engine already includes the overlay network in the route list it passes to
`configureInterface`, but deriving it here keeps the invariant local to the code
that changed rather than depending on the engine's route list.

Edge cases are no-ops rather than failures: an address that is already a single
host adds no route, and a malformed prefix is logged and skipped instead of
throwing away the whole tunnel.

## Verification

Tested on a Pixel running Android 17 (API 37), before and after, on the same
device and the same account. The client's own overlay address is
`100.91.96.107`; `192.168.50.0/24` is a network routed through a peer.

The tunnel afterwards — host address, overlay as a plain route, no broadcast
entry in the local table:

```
tun0: inet 100.91.96.107/32
100.91.0.0/16 dev tun0 table 1123 proto static
```

From Termux (`targetSdk=37`, does not declare `ACCESS_LOCAL_NETWORK`, so it can
never obtain it):

```
$ ping -c3 192.168.50.1
3 packets transmitted, 3 received, 0% packet loss
rtt min/avg/max/mdev = 8.303/30.948/70.291/27.925 ms

$ ping -c3 100.91.96.107
3 packets transmitted, 3 received, 0% packet loss
rtt min/avg/max/mdev = 0.179/0.286/0.367/0.078 ms
```

Both of these returned `Operation not permitted` before the change, and TCP to
the same destinations hung until timeout.

## Compatibility

`addAddress` with a host prefix is accepted on every supported API level, so no
`minSdk` change and no version-gated branch is needed. The change touches one
file and no submodule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overlay network configuration by assigning individual host addresses while preserving connectivity to the complete overlay network.
  * Added support for both IPv4 and IPv6 network routes.
  * Improved handling of invalid or unsupported network prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->