### PR TITLE
Use string resources for connection status and tab labels

### DIFF
--- a/app/src/main/java/io/netbird/client/ui/home/BottomDialogFragment.java
+++ b/app/src/main/java/io/netbird/client/ui/home/BottomDialogFragment.java
@@ -135,11 +135,11 @@ public class BottomDialogFragment extends com.google.android.material.bottomshee
         new TabLayoutMediator(tabLayout, viewPager, (tab, position) -> {
             switch (position) {
                 case 0:
-                    tab.setText("Peers");
+                    tab.setText(R.string.tab_peers);
                     tab.setIcon(R.drawable.peers);
                     break;
                 case 1:
-                    tab.setText("Networks");
+                    tab.setText(R.string.tab_networks);
                     tab.setIcon(R.drawable.networks);
                     break;
                 default:

--- a/app/src/main/java/io/netbird/client/ui/home/ButtonAnimation.java
+++ b/app/src/main/java/io/netbird/client/ui/home/ButtonAnimation.java
@@ -5,6 +5,10 @@ import android.animation.AnimatorListenerAdapter;
 import android.util.Log;
 import android.widget.TextView;
 
+import androidx.annotation.StringRes;
+
+import io.netbird.client.R;
+
 import com.airbnb.lottie.LottieAnimationView;
 import com.airbnb.lottie.LottieDrawable;
 
@@ -13,13 +17,13 @@ class ButtonAnimation {
     private TextView textConnStatus;
 
     private enum AnimationState {
-        DISCONNECTED("Disconnected"),
-        CONNECTING("Connecting"),
-        CONNECTED("Connected"),
-        DISCONNECTING("Disconnecting");
+        DISCONNECTED(R.string.main_status_disconnected),
+        CONNECTING(R.string.main_status_connecting),
+        CONNECTED(R.string.main_status_connected),
+        DISCONNECTING(R.string.main_status_disconnecting);
 
-        private final String text;
-        AnimationState(String text) { this.text = text; }
+        @StringRes private final int text;
+        AnimationState(@StringRes int text) { this.text = text; }
     }
 
     private AnimationState currentState = AnimationState.DISCONNECTED;
@@ -175,7 +179,7 @@ class ButtonAnimation {
         });
     }
 
-    private void updateText(String text) {
+    private void updateText(@StringRes int text) {
         Log.i("ButtonAnimation", "set text: "+text);
         textConnStatus.post(() -> textConnStatus.setText(text));
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,9 @@
     <string name="menu_troubleshoot">Troubleshoot</string>
 
     <string name="main_status_disconnected">Disconnected</string>
+    <string name="main_status_connecting">Connecting</string>
+    <string name="main_status_connected">Connected</string>
+    <string name="main_status_disconnecting">Disconnecting</string>
     <string name="main_desc_bg_mask">background mask</string>
     <string name="main_desc_connect">connect-disconnect</string>
 
@@ -35,6 +38,8 @@
 
     <string name="btn_close">Close</string>
     <string name="peers_connected"><![CDATA[<b>%1$d</b> <b>of</b> <b>%2$d</b> Peers connected]]></string>
+    <string name="tab_peers">Peers</string>
+    <string name="tab_networks">Networks</string>
     <string name="peers_hint_search_peers">Search peers</string>
     <string name="peer_filter_all">All</string>
     <string name="peer_filter_idle">Idle</string>


### PR DESCRIPTION
### Problem

The connection status label starts out localizable and stops being so as soon as the app changes state.

`fragment_home.xml:95` sets the initial value from a resource:

```xml
android:text="@string/main_status_disconnected"
```

but `ButtonAnimation` overwrites that label with hardcoded literals on every state transition, so `main_status_disconnected` is the only one of the four that a translator can reach — and only until the first connect.

The tab labels in `BottomDialogFragment` have the same issue: `tab.setText("Peers")` and `tab.setText("Networks")`.

### Fix

Move the four status labels and the two tab labels to string resources. `main_status_disconnected` already existed; the other five are added with the exact strings that were previously hardcoded.

The enum now carries a `@StringRes int` instead of a `String`, and `updateText` takes the resource id — `TextView.setText(int)` resolves it against the view's context.

### Notes

No behaviour change: the English output is identical, character for character.

This does not add any translations — it only makes these strings reachable by one.

Two related spots were left alone to keep the diff small: the `default` branch's `tab.setText("Tab " + position)` (unreachable with the current two-page adapter) and `AboutFragment`'s `setText("unknown")` version fallback.

### Testing

`./gradlew assembleDebug` passes. Verified with `aapt2 dump resources` that the six strings compile, and confirmed the labels still render in English on a device.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Added localized string resources for connection statuses and navigation tabs.
  - Updated the interface to display “Connecting,” “Connected,” “Disconnecting,” “Peers,” and “Networks” through translatable text resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->