### PR TITLE
Let the resources search field take focus on a television

### DIFF
--- a/app/src/main/java/io/netbird/client/ui/home/NetworksFragment.java
+++ b/app/src/main/java/io/netbird/client/ui/home/NetworksFragment.java
@@ -74,8 +74,6 @@ public class NetworksFragment extends Fragment {
 
         if (PlatformUtils.isAndroidTV(requireContext())) {
             binding.zeroPeerLayout.btnLearnWhy.setVisibility(View.GONE);
-            binding.searchView.setFocusable(false);
-            binding.searchView.setFocusableInTouchMode(false);
         } else {
             ZeroPeerView.setupLearnWhyClick(binding.zeroPeerLayout, requireContext());
         }


### PR DESCRIPTION
The resources list disables focus on its search field when running on a television, which leaves a field that is drawn, looks editable, and can never be used: it cannot take D-pad focus, so it can never open the keyboard or hold a cursor.

Focus alone does not raise a keyboard on a television, since that needs an explicit select, so the field can be reachable without getting in the way of navigating to the list below it.

- Stop disabling focus on the resources search field on Android TV

The peers list does the same thing to its own search field and filter icon, and the comment there attributes it to a navigation drawer that no longer exists in the app. Left alone here to keep this change to one screen; worth deciding separately whether that one should follow.
