### PR TITLE
Fix how the management-server screen judges a self-hosted URL

### DIFF
--- a/app/src/main/java/io/netbird/client/ui/server/ManagementUrl.java
+++ b/app/src/main/java/io/netbird/client/ui/server/ManagementUrl.java
@@ -1,5 +1,8 @@
 package io.netbird.client.ui.server;
 
+import android.security.NetworkSecurityPolicy;
+import android.util.Log;
+
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Locale;
@@ -10,6 +13,8 @@ import java.util.regex.Pattern;
  * mirroring the desktop's useManagementUrl hook.
  */
 public final class ManagementUrl {
+
+    private static final String LOGTAG = "ManagementUrl";
 
     /** Management URL of NetBird's hosted service. */
     public static final String CLOUD = "https://api.netbird.io:443";
@@ -67,6 +72,16 @@ public final class ManagementUrl {
      * <p>Blocking call — run it off the main thread.
      */
     public static boolean isReachable(String url) {
+        if (!canProbe(url)) {
+            // Not an answer this can give, so it does not pretend to. The
+            // engine reaches the server with Go's own networking, which is not
+            // bound by the platform's cleartext policy the way this probe is,
+            // so a plain-HTTP server that the probe may not touch is still one
+            // the client can use. Reporting it unreachable would warn about a
+            // URL that works.
+            return true;
+        }
+
         HttpURLConnection connection = null;
         try {
             connection = (HttpURLConnection) new URL(url).openConnection();
@@ -76,11 +91,35 @@ public final class ManagementUrl {
             connection.getResponseCode();
             return true;
         } catch (Exception e) {
+            // Logged because the reason is the whole diagnostic value: no
+            // route, a name that does not resolve, and a rejected certificate
+            // all arrive here and all show the user the same sentence.
+            Log.d(LOGTAG, "management server " + url + " did not answer the probe", e);
             return false;
         } finally {
             if (connection != null) {
                 connection.disconnect();
             }
+        }
+    }
+
+    /**
+     * Whether the probe is allowed to make this request at all. An app
+     * targeting API 28 or later has cleartext denied unless it opts in, and
+     * this one does not, so an http:// URL fails on policy before any packet
+     * is sent.
+     */
+    private static boolean canProbe(String url) {
+        try {
+            URL parsed = new URL(url);
+            if (!"http".equalsIgnoreCase(parsed.getProtocol())) {
+                return true;
+            }
+            return NetworkSecurityPolicy.getInstance()
+                    .isCleartextTrafficPermitted(parsed.getHost());
+        } catch (Exception e) {
+            Log.d(LOGTAG, "cannot tell whether " + url + " is probeable", e);
+            return false;
         }
     }
 }

--- a/app/src/main/java/io/netbird/client/ui/server/ManagementUrl.java
+++ b/app/src/main/java/io/netbird/client/ui/server/ManagementUrl.java
@@ -4,6 +4,7 @@ import android.security.NetworkSecurityPolicy;
 import android.util.Log;
 
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Locale;
 import java.util.regex.Pattern;
@@ -72,7 +73,18 @@ public final class ManagementUrl {
      * <p>Blocking call — run it off the main thread.
      */
     public static boolean isReachable(String url) {
-        if (!canProbe(url)) {
+        URL parsed;
+        try {
+            parsed = new URL(url);
+        } catch (MalformedURLException e) {
+            // Nothing to probe, and nothing the engine could dial either, so
+            // this is a genuine negative rather than a question the probe
+            // cannot answer.
+            Log.d(LOGTAG, "management server " + url + " is not a URL", e);
+            return false;
+        }
+
+        if (!cleartextPermitted(parsed)) {
             // Not an answer this can give, so it does not pretend to. The
             // engine reaches the server with Go's own networking, which is not
             // bound by the platform's cleartext policy the way this probe is,
@@ -84,7 +96,7 @@ public final class ManagementUrl {
 
         HttpURLConnection connection = null;
         try {
-            connection = (HttpURLConnection) new URL(url).openConnection();
+            connection = (HttpURLConnection) parsed.openConnection();
             connection.setConnectTimeout(REACHABILITY_TIMEOUT_MS);
             connection.setReadTimeout(REACHABILITY_TIMEOUT_MS);
             connection.setRequestMethod("GET");
@@ -104,22 +116,15 @@ public final class ManagementUrl {
     }
 
     /**
-     * Whether the probe is allowed to make this request at all. An app
-     * targeting API 28 or later has cleartext denied unless it opts in, and
-     * this one does not, so an http:// URL fails on policy before any packet
-     * is sent.
+     * Whether the platform will carry this request. An app targeting API 28 or
+     * later has cleartext denied unless it opts in, and this one does not, so
+     * an http:// URL fails on policy before any packet is sent. Anything else
+     * is permitted as far as this policy is concerned.
      */
-    private static boolean canProbe(String url) {
-        try {
-            URL parsed = new URL(url);
-            if (!"http".equalsIgnoreCase(parsed.getProtocol())) {
-                return true;
-            }
-            return NetworkSecurityPolicy.getInstance()
-                    .isCleartextTrafficPermitted(parsed.getHost());
-        } catch (Exception e) {
-            Log.d(LOGTAG, "cannot tell whether " + url + " is probeable", e);
-            return false;
+    private static boolean cleartextPermitted(URL url) {
+        if (!"http".equalsIgnoreCase(url.getProtocol())) {
+            return true;
         }
+        return NetworkSecurityPolicy.getInstance().isCleartextTrafficPermitted(url.getHost());
     }
 }

--- a/app/src/main/java/io/netbird/client/ui/server/ManagementUrl.java
+++ b/app/src/main/java/io/netbird/client/ui/server/ManagementUrl.java
@@ -5,6 +5,8 @@ import android.util.Log;
 
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Locale;
 import java.util.regex.Pattern;
@@ -26,7 +28,8 @@ public final class ManagementUrl {
     private static final String LEGACY_CLOUD = "https://api.wiretrustee.com:443";
 
     // Same syntactic check as the desktop UI: host is a domain, localhost or
-    // IPv4, with optional scheme, port, path, query and fragment.
+    // IPv4, with optional scheme, port, path, query and fragment. A bracketed
+    // IPv6 literal does not go through here, see isValid.
     private static final Pattern URL_PATTERN = Pattern.compile(
             "^(https?://)?"
                     + "((([a-z\\d]([a-z\\d-]*[a-z\\d])?)\\.)+[a-z]{2,}|localhost|"
@@ -49,9 +52,37 @@ public final class ManagementUrl {
         return CLOUD.equals(trimmed) || LEGACY_CLOUD.equals(trimmed);
     }
 
+    /**
+     * Whether the string is a syntactically usable management URL. The scheme,
+     * port, path, query and fragment are all optional; the host may be a
+     * domain, localhost, an IPv4 address or an IPv6 literal in brackets.
+     */
     public static boolean isValid(String url) {
         String trimmed = url == null ? "" : url.trim();
-        return !trimmed.isEmpty() && URL_PATTERN.matcher(trimmed).matches();
+        if (trimmed.isEmpty()) {
+            return false;
+        }
+        if (trimmed.indexOf('[') >= 0) {
+            return hasIpv6Host(trimmed);
+        }
+        return URL_PATTERN.matcher(trimmed).matches();
+    }
+
+    /**
+     * Whether the URL's host is a bracketed IPv6 literal. Left to java.net.URI
+     * rather than the pattern above, so the address grammar is checked by a
+     * parser instead of a hand-written character class.
+     */
+    private static boolean hasIpv6Host(String url) {
+        String host;
+        try {
+            host = new URI(normalize(url)).getHost();
+        } catch (URISyntaxException e) {
+            return false;
+        }
+        // getHost keeps the brackets for an IPv6 literal, and returns null for
+        // an authority the parser could not read as host and port.
+        return host != null && host.startsWith("[") && host.endsWith("]");
     }
 
     /** Adds the https:// scheme when the user omitted it. */

--- a/app/src/test/java/io/netbird/client/ui/server/ManagementUrlTest.java
+++ b/app/src/test/java/io/netbird/client/ui/server/ManagementUrlTest.java
@@ -1,0 +1,53 @@
+package io.netbird.client.ui.server;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class ManagementUrlTest {
+
+    @Test
+    public void isValid_acceptsDomainsLocalhostAndIpv4() {
+        assertTrue(ManagementUrl.isValid("https://api.netbird.io:443"));
+        assertTrue(ManagementUrl.isValid("api.netbird.io"));
+        assertTrue(ManagementUrl.isValid("http://localhost:8080"));
+        assertTrue(ManagementUrl.isValid("https://10.0.0.1:443/path"));
+    }
+
+    @Test
+    public void isValid_acceptsIpv6Literals() {
+        assertTrue(ManagementUrl.isValid("https://[2001:db8::1]:443"));
+        // Without a scheme, since normalize adds it later anyway.
+        assertTrue(ManagementUrl.isValid("[2001:db8::1]:443"));
+        // Both spellings of the same address, plus the awkward middles.
+        assertTrue(ManagementUrl.isValid("https://[2001:0db8:0000:0000:0000:0000:0000:0001]"));
+        assertTrue(ManagementUrl.isValid("https://[::1]/path?q=1#f"));
+        assertTrue(ManagementUrl.isValid("https://[::]"));
+        assertTrue(ManagementUrl.isValid("https://[::ffff:192.0.2.1]:443"));
+    }
+
+    @Test
+    public void isValid_rejectsMalformedIpv6Literals() {
+        assertFalse(ManagementUrl.isValid("https://[2001:db8::1"));
+        assertFalse(ManagementUrl.isValid("https://[::zz]"));
+        assertFalse(ManagementUrl.isValid("https://[1:2:3:4:5:6:7:8:9]"));
+        assertFalse(ManagementUrl.isValid("https://[]"));
+        // An unbracketed IPv6 address has no port boundary, so it is not a URL.
+        assertFalse(ManagementUrl.isValid("https://2001:db8::1:443"));
+    }
+
+    @Test
+    public void isValid_rejectsEmptyAndGarbage() {
+        assertFalse(ManagementUrl.isValid(null));
+        assertFalse(ManagementUrl.isValid("   "));
+        assertFalse(ManagementUrl.isValid("not a url"));
+    }
+
+    @Test
+    public void normalize_keepsBracketedHost() {
+        assertEquals("https://[2001:db8::1]:443", ManagementUrl.normalize("[2001:db8::1]:443"));
+        assertEquals("http://[::1]:8080", ManagementUrl.normalize("http://[::1]:8080"));
+    }
+}


### PR DESCRIPTION
The reachability probe on the management-server screen reports a plain-HTTP server as unreachable, so a self-hosted URL that the client can actually use is shown with a warning and a &#34;Continue anyway&#34; button.

The probe is the only part of the app subject to the platform&#39;s cleartext policy: an app targeting API 28 or later has cleartext denied unless it opts in, and this one does not, so the request fails on policy before a packet is sent. The engine reaches the same server with its own networking, which that policy does not govern.

The same screen also rejected an IPv6 management URL outright, since the syntax check only covered domains, localhost and IPv4.

- Skip the probe, rather than reporting a failure, when the platform will not permit the request in the first place
- Log the reason a probe failed, since no route, a name that does not resolve and a rejected certificate all end up showing the user the same sentence
- Report a URL that cannot be parsed as unreachable instead of treating it as a probe that could not be answered
- Accept an IPv6 literal in brackets, with the address grammar left to the URI parser rather than a hand-written pattern

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved management server connectivity checks on Android by respecting platform cleartext traffic policies.
  * Avoided unnecessary connection attempts when network probing is not permitted.
  * Added diagnostic logging when connectivity checks fail.

