### PR TITLE
Adapt the e2e profile flow to the overflow-menu profile rows

### DIFF
--- a/app/src/androidTest/java/io/netbird/client/e2e/DnsResolutionTest.java
+++ b/app/src/androidTest/java/io/netbird/client/e2e/DnsResolutionTest.java
@@ -63,6 +63,8 @@ public class DnsResolutionTest {
      * peer-ready sequence).
      */
     private static final long CONNECT_TIMEOUT_SEC = 20;
+    /** Time budget for the first network map (and with it the DNS zones) to land. */
+    private static final long NETWORK_MAP_TIMEOUT_SEC = 30;
     /** Time budget for DNS to start resolving once the engine is connected. */
     private static final long RESOLVE_TIMEOUT_SEC = 90;
     private VpnTestHarness harness;
@@ -109,6 +111,17 @@ public class DnsResolutionTest {
         }
         assertTrue("VPN did not reach connected state within " + CONNECT_TIMEOUT_SEC + "s",
                 connected);
+
+        // Do not query before the zones exist: a miss in the gap between
+        // Connected and the first network map is negative-cached by Android and
+        // no retry below would ever reach the NetBird DNS again.
+        boolean mapApplied = harness.awaitPeerListed(NETWORK_MAP_TIMEOUT_SEC);
+        if (!mapApplied) {
+            LoginFlow.dumpScreenshot(harness.device(), "dns-network-map-timeout");
+        }
+        assertTrue("no peer was listed within " + NETWORK_MAP_TIMEOUT_SEC
+                + "s of connecting, so the network map (and its DNS config) never arrived",
+                mapApplied);
 
         // FQDN resolves to the peer's private address through the tunnel DNS.
         boolean fqdnResolved = harness.waitForResolve(PEER_FQDN, EXPECTED_IP, RESOLVE_TIMEOUT_SEC);

--- a/app/src/androidTest/java/io/netbird/client/e2e/LoginFlow.java
+++ b/app/src/androidTest/java/io/netbird/client/e2e/LoginFlow.java
@@ -128,24 +128,23 @@ final class LoginFlow {
         return profileName;
     }
 
-    /** Make {@code profileName} the active profile via its row's Switch button. */
+    /** Make {@code profileName} the active profile by tapping its row. */
     private static void switchToProfile(MainActivity activity, UiDevice device, String profileName)
             throws InterruptedException {
         openProfiles(device);
 
-        UiObject2 switchBtn = rowAction(device, profileName, "btn_switch");
-        if (switchBtn == null) {
-            dumpScreenshot(device, "switch-button-missing");
+        UiObject2 row = profileRow(device, profileName);
+        if (row == null) {
+            dumpScreenshot(device, "switch-row-missing");
             dumpVisibleProfiles(device);
-            fail("btn_switch not found for profile " + profileName);
+            fail("profile row not found for " + profileName);
         }
-        if (!switchBtn.isEnabled()) {
-            // Already the active profile — the button reads "Active" and is
-            // disabled, so there is nothing to switch.
+        if (isActiveRow(row)) {
+            // The row's click listener is a no-op for the active profile.
             Log.i(TAG, "Profile " + profileName + " is already active");
             return;
         }
-        switchBtn.click();
+        row.click();
         confirmDialog(device);
         device.waitForIdle();
         Log.i(TAG, "Switched to profile " + profileName);
@@ -209,7 +208,7 @@ final class LoginFlow {
         // A rolled-back profile leaves no row behind, so its presence is the
         // proof that creation plus enrolment both went through.
         openProfiles(device);
-        if (rowAction(device, profileName, "btn_remove") == null) {
+        if (profileRow(device, profileName) == null) {
             dumpScreenshot(device, "login-profile-missing");
             dumpVisibleProfiles(device);
             fail("Profile " + profileName + " is not in the list after login —"
@@ -278,35 +277,47 @@ final class LoginFlow {
     /**
      * Remove a profile created by {@link #createProfileAndLogin}. A profile
      * can't be removed while active, so we switch to the built-in "default"
-     * profile first, then remove the test profile. We assert on the profile UI:
-     * a missing switch/remove button fails the test — it's a real UI defect,
-     * not something to swallow.
+     * profile first, then remove the test profile through its row's overflow
+     * menu. We assert on the profile UI: a missing row, menu button or menu
+     * item fails the test — it's a real UI defect, not something to swallow.
      */
     static void removeProfile(MainActivity activity, UiDevice device, String profileName)
             throws InterruptedException {
         openProfiles(device);
 
-        // The active profile shows a disabled "Active" chip where the inactive
-        // ones show "Switch", so a missing button here means default is already
-        // active — nothing to switch away from.
-        UiObject2 switchBtn = rowAction(device, DEFAULT_PROFILE, "btn_switch");
-        if (switchBtn != null && switchBtn.isEnabled()) {
-            switchBtn.click();
+        UiObject2 defaultRow = profileRow(device, DEFAULT_PROFILE);
+        if (defaultRow != null && !isActiveRow(defaultRow)) {
+            defaultRow.click();
             confirmDialog(device);
             device.waitForIdle();
 
-            // Switching profiles bounces back to Home, so return to the
-            // profiles screen before looking for the remove button.
+            // Switching profiles pops back to Settings, so return to the
+            // profiles screen before looking for the test profile.
             openProfiles(device);
         }
 
-        UiObject2 removeBtn = rowAction(device, profileName, "btn_remove");
-        if (removeBtn == null) {
-            dumpScreenshot(device, "remove-button-missing");
+        UiObject2 row = profileRow(device, profileName);
+        if (row == null) {
+            dumpScreenshot(device, "remove-row-missing");
             dumpVisibleProfiles(device);
-            fail("btn_remove not found for profile " + profileName);
+            fail("profile row not found for " + profileName);
         }
-        removeBtn.click();
+        UiObject2 menuBtn = row.findObject(By.res(PACKAGE, "btn_profile_menu"));
+        if (menuBtn == null) {
+            dumpScreenshot(device, "profile-menu-button-missing");
+            fail("btn_profile_menu not found for profile " + profileName);
+        }
+        menuBtn.click();
+
+        // Popup menu items carry no app resource id, so match the label; read
+        // it from the app's own resources to stay locale-independent.
+        String removeLabel = activity.getString(R.string.profiles_remove);
+        UiObject2 removeItem = device.wait(Until.findObject(By.text(removeLabel)), UI_TIMEOUT_MS);
+        if (removeItem == null) {
+            dumpScreenshot(device, "remove-menu-item-missing");
+            fail("'" + removeLabel + "' menu item not shown for profile " + profileName);
+        }
+        removeItem.click();
         confirmDialog(device);
         device.waitForIdle();
         Log.i(TAG, "Removed profile " + profileName);
@@ -446,11 +457,10 @@ final class LoginFlow {
     }
 
     /**
-     * Find the action button with {@code resId} inside the profile row whose
-     * {@code text_profile_name} matches {@code profileName}. Returns null if no
-     * such row/button is visible.
+     * Find the profile row whose {@code text_profile_name} matches
+     * {@code profileName}. Returns null if no such row is visible.
      */
-    private static UiObject2 rowAction(UiDevice device, String profileName, String resId) {
+    private static UiObject2 profileRow(UiDevice device, String profileName) {
         BySelector labelSel = By.res(PACKAGE, "text_profile_name").text(profileName);
         UiObject2 label = device.wait(Until.findObject(labelSel), UI_TIMEOUT_MS);
         if (label == null) {
@@ -462,17 +472,22 @@ final class LoginFlow {
         if (label == null) {
             return null;
         }
-        // The control lives in the same row; walk up and search within it.
+        // The row is the list item itself: it owns the click listener, the
+        // Active badge and the overflow menu button.
         UiObject2 row = label.getParent();
-        BySelector sel = By.res(PACKAGE, resId);
+        BySelector menuSel = By.res(PACKAGE, "btn_profile_menu");
         for (int i = 0; i < 5 && row != null; i++) {
-            UiObject2 ctrl = row.findObject(sel);
-            if (ctrl != null) {
-                return ctrl;
+            if (row.findObject(menuSel) != null) {
+                return row;
             }
             row = row.getParent();
         }
         return null;
+    }
+
+    /** The Active badge is only in the tree for the active profile's row. */
+    private static boolean isActiveRow(UiObject2 row) {
+        return row.findObject(By.res(PACKAGE, "badge_active")) != null;
     }
 
     /**

--- a/app/src/androidTest/java/io/netbird/client/e2e/VpnTestHarness.java
+++ b/app/src/androidTest/java/io/netbird/client/e2e/VpnTestHarness.java
@@ -149,6 +149,39 @@ final class VpnTestHarness {
     }
 
     /**
+     * Wait until the Peers tab lists at least one peer, then return to Home.
+     *
+     * <p>The status reads Connected before the first network map is applied,
+     * and the DNS zones arrive with that map. A lookup fired in between is
+     * forwarded to the plain upstream, answered NXDOMAIN, and negative-cached
+     * by Android for the zone's SOA TTL — so later retries never reach the
+     * NetBird DNS at all and the check stays dead for the whole budget. The
+     * engine registers the DNS config before it adds the map's peers, so a
+     * listed peer proves the zones are in place.
+     *
+     * @return true if a peer row appeared within the timeout
+     */
+    boolean awaitPeerListed(long timeoutSec) {
+        UiObject2 peersTab = device.wait(
+                Until.findObject(By.res(LoginFlow.PACKAGE, "nav_peers")), UI_TIMEOUT_MS);
+        assertNotNull("nav_peers tab must be present", peersTab);
+        peersTab.click();
+
+        boolean listed = device.wait(
+                Until.hasObject(By.res(LoginFlow.PACKAGE, "fqdn")), timeoutSec * 1000L);
+        Log.i(TAG, listed ? "Peers tab lists a peer"
+                : "No peer listed within " + timeoutSec + "s");
+
+        UiObject2 homeTab = device.wait(
+                Until.findObject(By.res(LoginFlow.PACKAGE, "nav_home")), UI_TIMEOUT_MS);
+        assertNotNull("nav_home tab must be present", homeTab);
+        homeTab.click();
+        device.wait(Until.hasObject(By.res(LoginFlow.PACKAGE, "text_connection_status")),
+                UI_TIMEOUT_MS);
+        return listed;
+    }
+
+    /**
      * Toggle the emulator's virtual WiFi transport. {@code svc wifi} works on
      * the API 30 image the e2e workflow runs on (removed in API 31+, where
      * {@code cmd wifi set-wifi-enabled} replaces it).


### PR DESCRIPTION
The profile list no longer has per-row Switch and Remove buttons. A row is tapped to switch, the active row shows a badge, and Remove lives in the row's overflow menu. LoginFlow still looked for btn_switch and btn_remove, so the login smoke test failed on a profile that was actually created and enrolled, and fail-fast skipped the rest of the suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved DNS resolution test reliability by waiting for network configuration to be applied before checking DNS queries.
  - Added validation that peers appear in the app before proceeding with DNS-related checks.
  - Updated profile-management tests to support the redesigned profile rows, active-profile indicator, and overflow actions.
  - Added timeout handling and diagnostic screenshots when network configuration is not applied in time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->