### PR TITLE
Add an anonymization level picker to the debug bundle screen

### DIFF
--- a/app/src/main/java/io/netbird/client/MainActivity.java
+++ b/app/src/main/java/io/netbird/client/MainActivity.java
@@ -612,11 +612,11 @@ public class MainActivity extends AppCompatActivity implements ServiceAccessor, 
     }
 
     @Override
-    public String debugBundle(boolean anonymize) throws Exception {
+    public String debugBundle(boolean anonymize, String anonymizeLevel) throws Exception {
         if (mBinder == null) {
             throw new Exception("VPN service not connected");
         }
-        return mBinder.debugBundle(anonymize);
+        return mBinder.debugBundle(anonymize, anonymizeLevel);
     }
 
     @Override

--- a/app/src/main/java/io/netbird/client/ServiceAccessor.java
+++ b/app/src/main/java/io/netbird/client/ServiceAccessor.java
@@ -31,7 +31,7 @@ public interface ServiceAccessor {
     void addRouteChangeListener(RouteChangeListener listener);
     void removeRouteChangeListener(RouteChangeListener listener);
 
-    String debugBundle(boolean anonymize) throws Exception;
+    String debugBundle(boolean anonymize, String anonymizeLevel) throws Exception;
 
     /** SSO session deadline as unix seconds; 0 when unknown or not bound. */
     long sessionExpiresAt();

--- a/app/src/main/java/io/netbird/client/ui/troubleshoot/AnonymizeLevelSheet.java
+++ b/app/src/main/java/io/netbird/client/ui/troubleshoot/AnonymizeLevelSheet.java
@@ -1,0 +1,78 @@
+package io.netbird.client.ui.troubleshoot;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
+
+import io.netbird.client.databinding.SheetAnonymizeLevelBinding;
+import io.netbird.client.tool.Preferences;
+
+public class AnonymizeLevelSheet extends BottomSheetDialogFragment {
+
+    public interface OnLevelChangedListener {
+        void onAnonymizeLevelChanged(String level);
+    }
+
+    private static final String ARG_LEVEL = "level";
+
+    private SheetAnonymizeLevelBinding binding;
+
+    public static AnonymizeLevelSheet newInstance(String current) {
+        AnonymizeLevelSheet sheet = new AnonymizeLevelSheet();
+        Bundle args = new Bundle();
+        args.putString(ARG_LEVEL, current);
+        sheet.setArguments(args);
+        return sheet;
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        binding = SheetAnonymizeLevelBinding.inflate(inflater, container, false);
+
+        binding.levelRowNone.setOnClickListener(v -> pick(Preferences.ANONYMIZE_LEVEL_NONE));
+        binding.levelRowDefault.setOnClickListener(v -> pick(Preferences.ANONYMIZE_LEVEL_DEFAULT));
+        binding.levelRowStrict.setOnClickListener(v -> pick(Preferences.ANONYMIZE_LEVEL_STRICT));
+
+        showCheckmarkFor(currentLevel());
+        return binding.getRoot();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
+    }
+
+    private String currentLevel() {
+        Bundle args = getArguments();
+        if (args == null) {
+            return Preferences.ANONYMIZE_LEVEL_DEFAULT;
+        }
+        return args.getString(ARG_LEVEL, Preferences.ANONYMIZE_LEVEL_DEFAULT);
+    }
+
+    private void showCheckmarkFor(String level) {
+        binding.levelCheckNone.setVisibility(
+                Preferences.ANONYMIZE_LEVEL_NONE.equals(level) ? View.VISIBLE : View.INVISIBLE);
+        binding.levelCheckStrict.setVisibility(
+                Preferences.ANONYMIZE_LEVEL_STRICT.equals(level) ? View.VISIBLE : View.INVISIBLE);
+        binding.levelCheckDefault.setVisibility(
+                Preferences.ANONYMIZE_LEVEL_NONE.equals(level) || Preferences.ANONYMIZE_LEVEL_STRICT.equals(level)
+                        ? View.INVISIBLE : View.VISIBLE);
+    }
+
+    private void pick(String level) {
+        if (getParentFragment() instanceof OnLevelChangedListener) {
+            ((OnLevelChangedListener) getParentFragment()).onAnonymizeLevelChanged(level);
+        }
+        dismiss();
+    }
+}

--- a/app/src/main/java/io/netbird/client/ui/troubleshoot/TroubleshootFragment.java
+++ b/app/src/main/java/io/netbird/client/ui/troubleshoot/TroubleshootFragment.java
@@ -20,16 +20,18 @@ import io.netbird.client.databinding.FragmentTroubleshootBinding;
 import io.netbird.client.tool.Preferences;
 import io.netbird.client.tool.ProfileManagerWrapper;
 
-public class TroubleshootFragment extends Fragment {
+public class TroubleshootFragment extends Fragment implements AnonymizeLevelSheet.OnLevelChangedListener {
 
     private static final String LOGTAG = "TroubleshootFragment";
+
     private FragmentTroubleshootBinding binding;
+    private Preferences preferences;
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         binding = FragmentTroubleshootBinding.inflate(inflater, container, false);
 
-        Preferences preferences = new Preferences(inflater.getContext());
+        preferences = new Preferences(inflater.getContext());
         binding.switchTraceLog.setChecked(preferences.isTraceLogEnabled());
 
         binding.switchTraceLog.setOnCheckedChangeListener((buttonView, isChecked) -> {
@@ -44,9 +46,10 @@ public class TroubleshootFragment extends Fragment {
             binding.switchTraceLog.toggle();
         });
 
-        binding.anonymizeLayout.setOnClickListener(v -> {
-            binding.switchAnonymize.toggle();
-        });
+        updateAnonymizeValue();
+        binding.anonymizeLayout.setOnClickListener(v ->
+                AnonymizeLevelSheet.newInstance(preferences.getAnonymizeLevel())
+                        .show(getChildFragmentManager(), "anonymize_level"));
 
         initializeRemoteJobsSwitch(inflater.getContext());
 
@@ -61,6 +64,18 @@ public class TroubleshootFragment extends Fragment {
     public void onDestroyView() {
         super.onDestroyView();
         binding = null;
+    }
+
+    @Override
+    public void onAnonymizeLevelChanged(String level) {
+        preferences.setAnonymizeLevel(level);
+        if (binding != null) {
+            updateAnonymizeValue();
+        }
+    }
+
+    private void updateAnonymizeValue() {
+        binding.anonymizeValue.setText(anonymizeLevelLabel(preferences.getAnonymizeLevel()));
     }
 
     private void initializeRemoteJobsSwitch(Context context) {
@@ -88,11 +103,15 @@ public class TroubleshootFragment extends Fragment {
             return;
         }
 
-        boolean anonymize = binding.switchAnonymize.isChecked();
+        String level = preferences.getAnonymizeLevel();
+        boolean anonymize = !Preferences.ANONYMIZE_LEVEL_NONE.equals(level);
+        String anonymizeLevel = Preferences.ANONYMIZE_LEVEL_STRICT.equals(level)
+                ? Preferences.ANONYMIZE_LEVEL_STRICT
+                : Preferences.ANONYMIZE_LEVEL_DEFAULT;
         binding.buttonDebugBundle.setEnabled(false);
         new Thread(() -> {
             try {
-                String key = ((ServiceAccessor) activity).debugBundle(anonymize);
+                String key = ((ServiceAccessor) activity).debugBundle(anonymize, anonymizeLevel);
                 activity.runOnUiThread(() -> {
                     if (binding == null || !isAdded()) return;
                     binding.buttonDebugBundle.setEnabled(true);
@@ -110,5 +129,16 @@ public class TroubleshootFragment extends Fragment {
                 });
             }
         }).start();
+    }
+
+    private static int anonymizeLevelLabel(String level) {
+        switch (level) {
+            case Preferences.ANONYMIZE_LEVEL_NONE:
+                return R.string.troubleshoot_anonymize_none;
+            case Preferences.ANONYMIZE_LEVEL_STRICT:
+                return R.string.troubleshoot_anonymize_strict;
+            default:
+                return R.string.troubleshoot_anonymize_default;
+        }
     }
 }

--- a/app/src/main/res/layout/fragment_troubleshoot.xml
+++ b/app/src/main/res/layout/fragment_troubleshoot.xml
@@ -54,39 +54,6 @@
         <include layout="@layout/list_item_setting_divider" />
 
         <LinearLayout
-            android:id="@+id/anonymize_layout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@drawable/settings_row_bg"
-            android:clickable="true"
-            android:focusable="true"
-            android:gravity="center_vertical"
-            android:minHeight="56dp"
-            android:orientation="horizontal"
-            android:paddingStart="20dp"
-            android:paddingEnd="16dp">
-
-            <TextView
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="@string/troubleshoot_anonymize"
-                android:textColor="@color/nb_txt"
-                android:textSize="16sp" />
-
-            <com.google.android.material.switchmaterial.SwitchMaterial
-                style="@style/Widget.NetBird.Switch"
-                android:id="@+id/switch_anonymize"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="16dp"
-                android:clickable="false"
-                android:focusable="false" />
-        </LinearLayout>
-
-        <include layout="@layout/list_item_setting_divider" />
-
-        <LinearLayout
             android:id="@+id/allow_remote_jobs_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -137,6 +104,53 @@
         <TextView
             style="@style/SettingsSectionHeader"
             android:text="@string/troubleshoot_section_debug_bundle" />
+
+        <LinearLayout
+            android:id="@+id/anonymize_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/settings_row_bg"
+            android:clickable="true"
+            android:focusable="true"
+            android:gravity="center_vertical"
+            android:minHeight="56dp"
+            android:orientation="horizontal"
+            android:paddingStart="20dp"
+            android:paddingEnd="16dp"
+            android:paddingTop="10dp"
+            android:paddingBottom="10dp">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/troubleshoot_anonymize"
+                    android:textColor="@color/nb_txt"
+                    android:textSize="16sp" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="2dp"
+                    android:text="@string/troubleshoot_anonymize_desc"
+                    android:textColor="@color/nb_txt_light"
+                    android:textSize="12sp" />
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/anonymize_value"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:textColor="@color/nb_txt_light"
+                android:textSize="14sp"
+                tools:text="@string/troubleshoot_anonymize_default" />
+        </LinearLayout>
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/sheet_anonymize_level.xml
+++ b/app/src/main/res/layout/sheet_anonymize_level.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingBottom="16dp">
+
+    <View
+        android:layout_width="36dp"
+        android:layout_height="4dp"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="12dp"
+        android:layout_marginBottom="8dp"
+        android:background="@drawable/separator" />
+
+    <TextView
+        style="@style/SettingsSectionHeader"
+        android:text="@string/troubleshoot_anonymize" />
+
+    <LinearLayout
+        android:id="@+id/level_row_none"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/sheet_row_bg"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center_vertical"
+        android:minHeight="56dp"
+        android:orientation="horizontal"
+        android:paddingStart="20dp"
+        android:paddingEnd="20dp">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:paddingTop="10dp"
+            android:paddingBottom="10dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/troubleshoot_anonymize_none"
+                android:textColor="@color/nb_txt"
+                android:textSize="16sp" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:text="@string/troubleshoot_anonymize_none_description"
+                android:textColor="@color/nb_txt_light"
+                android:textSize="12sp" />
+        </LinearLayout>
+
+        <ImageView
+            android:id="@+id/level_check_none"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_check"
+            android:visibility="invisible"
+            app:tint="@color/nb_orange" />
+    </LinearLayout>
+
+    <include layout="@layout/list_item_setting_divider" />
+
+    <LinearLayout
+        android:id="@+id/level_row_default"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/sheet_row_bg"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center_vertical"
+        android:minHeight="56dp"
+        android:orientation="horizontal"
+        android:paddingStart="20dp"
+        android:paddingEnd="20dp">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:paddingTop="10dp"
+            android:paddingBottom="10dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/troubleshoot_anonymize_default"
+                android:textColor="@color/nb_txt"
+                android:textSize="16sp" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:text="@string/troubleshoot_anonymize_default_description"
+                android:textColor="@color/nb_txt_light"
+                android:textSize="12sp" />
+        </LinearLayout>
+
+        <ImageView
+            android:id="@+id/level_check_default"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_check"
+            android:visibility="invisible"
+            app:tint="@color/nb_orange" />
+    </LinearLayout>
+
+    <include layout="@layout/list_item_setting_divider" />
+
+    <LinearLayout
+        android:id="@+id/level_row_strict"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/sheet_row_bg"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center_vertical"
+        android:minHeight="56dp"
+        android:orientation="horizontal"
+        android:paddingStart="20dp"
+        android:paddingEnd="20dp">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:paddingTop="10dp"
+            android:paddingBottom="10dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/troubleshoot_anonymize_strict"
+                android:textColor="@color/nb_txt"
+                android:textSize="16sp" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:text="@string/troubleshoot_anonymize_strict_description"
+                android:textColor="@color/nb_txt_light"
+                android:textSize="12sp" />
+        </LinearLayout>
+
+        <ImageView
+            android:id="@+id/level_check_strict"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_check"
+            android:visibility="invisible"
+            app:tint="@color/nb_orange" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -119,6 +119,13 @@
     <string name="advanced_tracelog">Trace-Logs aktivieren.</string>
     <string name="troubleshoot_debug_bundle">Debug-Paket hochladen</string>
     <string name="troubleshoot_anonymize">Sensible Daten anonymisieren</string>
+    <string name="troubleshoot_anonymize_desc">Verbirgt IP-Adressen, Domains und andere sensible Werte.</string>
+    <string name="troubleshoot_anonymize_none">Keine</string>
+    <string name="troubleshoot_anonymize_none_description">Alles bleibt lesbar. Nur innerhalb Ihrer Organisation weitergeben.</string>
+    <string name="troubleshoot_anonymize_default">Standard</string>
+    <string name="troubleshoot_anonymize_default_description">Verbirgt öffentliche IP-Adressen und Domains. Interne IPv4-Adressen und Peer-Namen bleiben für den Support lesbar.</string>
+    <string name="troubleshoot_anonymize_strict">Strikt</string>
+    <string name="troubleshoot_anonymize_strict_description">Verbirgt zusätzlich private, CGNAT- und Link-Local-Adressen, Peer-Namen und WireGuard-Schlüssel. Außerhalb Ihrer Organisation verwenden.</string>
     <string name="troubleshoot_section_logging">Protokollierung</string>
     <string name="troubleshoot_section_debug_bundle">Debug-Paket</string>
     <string name="advanced_rosenpass">Rosenpass aktivieren</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -119,6 +119,13 @@
     <string name="advanced_tracelog">Activar el nivel de registro de seguimiento.</string>
     <string name="troubleshoot_debug_bundle">Subir paquete de diagnóstico</string>
     <string name="troubleshoot_anonymize">Anonimizar datos sensibles</string>
+    <string name="troubleshoot_anonymize_desc">Oculta direcciones IP, dominios y otros valores sensibles.</string>
+    <string name="troubleshoot_anonymize_none">Ninguno</string>
+    <string name="troubleshoot_anonymize_none_description">Todo permanece legible. Compártelo solo dentro de tu organización.</string>
+    <string name="troubleshoot_anonymize_default">Predeterminado</string>
+    <string name="troubleshoot_anonymize_default_description">Oculta las direcciones IP públicas y los dominios. Las direcciones IPv4 internas y los nombres de los peers siguen legibles para el soporte.</string>
+    <string name="troubleshoot_anonymize_strict">Estricto</string>
+    <string name="troubleshoot_anonymize_strict_description">Oculta además las direcciones privadas, CGNAT y de enlace local, los nombres de los peers y las claves WireGuard. Úsalo fuera de tu organización.</string>
     <string name="troubleshoot_section_logging">Registro</string>
     <string name="troubleshoot_section_debug_bundle">Paquete de diagnóstico</string>
     <string name="advanced_rosenpass">Habilitar Rosenpass</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -119,6 +119,13 @@
     <string name="advanced_tracelog">Activer le niveau de journalisation trace.</string>
     <string name="troubleshoot_debug_bundle">Envoyer le lot de diagnostic</string>
     <string name="troubleshoot_anonymize">Anonymiser les données sensibles</string>
+    <string name="troubleshoot_anonymize_desc">Masque les adresses IP, les domaines et d\'autres valeurs sensibles.</string>
+    <string name="troubleshoot_anonymize_none">Aucune</string>
+    <string name="troubleshoot_anonymize_none_description">Tout reste lisible. À partager uniquement au sein de votre organisation.</string>
+    <string name="troubleshoot_anonymize_default">Par défaut</string>
+    <string name="troubleshoot_anonymize_default_description">Masque les adresses IP publiques et les domaines. Les adresses IPv4 internes et les noms des pairs restent lisibles pour le support.</string>
+    <string name="troubleshoot_anonymize_strict">Strict</string>
+    <string name="troubleshoot_anonymize_strict_description">Masque aussi les adresses privées, CGNAT et de lien local, les noms des pairs et les clés WireGuard. À utiliser hors de votre organisation.</string>
     <string name="troubleshoot_section_logging">Journalisation</string>
     <string name="troubleshoot_section_debug_bundle">Lot de diagnostic</string>
     <string name="advanced_rosenpass">Activer Rosenpass</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -119,6 +119,13 @@
     <string name="advanced_tracelog">Trace naplózási szint engedélyezése.</string>
     <string name="troubleshoot_debug_bundle">Hibakeresési csomag feltöltése</string>
     <string name="troubleshoot_anonymize">Érzékeny adatok anonimizálása</string>
+    <string name="troubleshoot_anonymize_desc">Elrejti az IP-címeket, a tartományokat és más érzékeny értékeket.</string>
+    <string name="troubleshoot_anonymize_none">Nincs</string>
+    <string name="troubleshoot_anonymize_none_description">Minden olvasható marad. Csak a szervezeten belül ossza meg.</string>
+    <string name="troubleshoot_anonymize_default">Alapértelmezett</string>
+    <string name="troubleshoot_anonymize_default_description">Elrejti a nyilvános IP-címeket és tartományokat. A belső IPv4-címek és a peer-nevek olvashatók maradnak a támogatás számára.</string>
+    <string name="troubleshoot_anonymize_strict">Szigorú</string>
+    <string name="troubleshoot_anonymize_strict_description">A privát, CGNAT és link-local címeket, a peer-neveket és a WireGuard-kulcsokat is elrejti. A szervezeten kívül ezt használja.</string>
     <string name="troubleshoot_section_logging">Naplózás</string>
     <string name="troubleshoot_section_debug_bundle">Hibakeresési csomag</string>
     <string name="advanced_rosenpass">Rosenpass engedélyezése</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -119,6 +119,13 @@
     <string name="advanced_tracelog">Abilita il livello di log di traccia.</string>
     <string name="troubleshoot_debug_bundle">Carica pacchetto di debug</string>
     <string name="troubleshoot_anonymize">Anonimizza dati sensibili</string>
+    <string name="troubleshoot_anonymize_desc">Nasconde indirizzi IP, domini e altri valori sensibili.</string>
+    <string name="troubleshoot_anonymize_none">Nessuna</string>
+    <string name="troubleshoot_anonymize_none_description">Tutto resta leggibile. Condividi solo all’interno della tua organizzazione.</string>
+    <string name="troubleshoot_anonymize_default">Predefinito</string>
+    <string name="troubleshoot_anonymize_default_description">Nasconde gli indirizzi IP pubblici e i domini. Gli indirizzi IPv4 interni e i nomi dei peer restano leggibili per il supporto.</string>
+    <string name="troubleshoot_anonymize_strict">Rigoroso</string>
+    <string name="troubleshoot_anonymize_strict_description">Nasconde anche gli indirizzi privati, CGNAT e link-local, i nomi dei peer e le chiavi WireGuard. Usalo fuori dalla tua organizzazione.</string>
     <string name="troubleshoot_section_logging">Registrazione</string>
     <string name="troubleshoot_section_debug_bundle">Pacchetto di debug</string>
     <string name="advanced_rosenpass">Abilita Rosenpass</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -119,6 +119,13 @@
     <string name="advanced_tracelog">トレースログレベルを有効にします。</string>
     <string name="troubleshoot_debug_bundle">デバッグバンドルをアップロード</string>
     <string name="troubleshoot_anonymize">機密データを匿名化</string>
+    <string name="troubleshoot_anonymize_desc">IP アドレス、ドメイン、その他の機密性の高い値を隠します。</string>
+    <string name="troubleshoot_anonymize_none">なし</string>
+    <string name="troubleshoot_anonymize_none_description">すべてそのまま残ります。組織内でのみ共有してください。</string>
+    <string name="troubleshoot_anonymize_default">デフォルト</string>
+    <string name="troubleshoot_anonymize_default_description">パブリック IP アドレスとドメインを隠します。内部 IPv4 アドレスとピア名はサポート向けに読める状態で残ります。</string>
+    <string name="troubleshoot_anonymize_strict">厳格</string>
+    <string name="troubleshoot_anonymize_strict_description">プライベート、CGNAT、リンクローカルのアドレス、ピア名、WireGuard 鍵も隠します。組織外へ共有する場合に使用します。</string>
     <string name="troubleshoot_section_logging">ログ</string>
     <string name="troubleshoot_section_debug_bundle">デバッグバンドル</string>
     <string name="advanced_rosenpass">Rosenpass を有効にする</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -119,6 +119,13 @@
     <string name="advanced_tracelog">Habilitar o nível de log de trace.</string>
     <string name="troubleshoot_debug_bundle">Enviar pacote de depuração</string>
     <string name="troubleshoot_anonymize">Anonimizar dados sensíveis</string>
+    <string name="troubleshoot_anonymize_desc">Oculta endereços IP, domínios e outros valores sensíveis.</string>
+    <string name="troubleshoot_anonymize_none">Nenhum</string>
+    <string name="troubleshoot_anonymize_none_description">Tudo permanece legível. Compartilhe apenas dentro da sua organização.</string>
+    <string name="troubleshoot_anonymize_default">Padrão</string>
+    <string name="troubleshoot_anonymize_default_description">Oculta os endereços IP públicos e os domínios. Os endereços IPv4 internos e os nomes dos peers continuam legíveis para o suporte.</string>
+    <string name="troubleshoot_anonymize_strict">Estrito</string>
+    <string name="troubleshoot_anonymize_strict_description">Oculta também os endereços privados, CGNAT e link-local, os nomes dos peers e as chaves WireGuard. Use fora da sua organização.</string>
     <string name="troubleshoot_section_logging">Registro</string>
     <string name="troubleshoot_section_debug_bundle">Pacote de depuração</string>
     <string name="advanced_rosenpass">Ativar Rosenpass</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -119,6 +119,13 @@
     <string name="advanced_tracelog">Включить уровень журналирования TRACE.</string>
     <string name="troubleshoot_debug_bundle">Загрузить отладочный пакет</string>
     <string name="troubleshoot_anonymize">Анонимизировать конфиденциальные данные</string>
+    <string name="troubleshoot_anonymize_desc">Скрывает IP-адреса, домены и другие конфиденциальные значения.</string>
+    <string name="troubleshoot_anonymize_none">Нет</string>
+    <string name="troubleshoot_anonymize_none_description">Всё остаётся читаемым. Передавайте только внутри вашей организации.</string>
+    <string name="troubleshoot_anonymize_default">По умолчанию</string>
+    <string name="troubleshoot_anonymize_default_description">Скрывает публичные IP-адреса и домены. Внутренние IPv4-адреса и имена пиров остаются читаемыми для поддержки.</string>
+    <string name="troubleshoot_anonymize_strict">Строгий</string>
+    <string name="troubleshoot_anonymize_strict_description">Скрывает также частные, CGNAT и link-local адреса, имена пиров и ключи WireGuard. Используйте за пределами вашей организации.</string>
     <string name="troubleshoot_section_logging">Журналирование</string>
     <string name="troubleshoot_section_debug_bundle">Отладочный пакет</string>
     <string name="advanced_rosenpass">Включить Rosenpass</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -119,6 +119,13 @@
     <string name="advanced_tracelog">启用跟踪日志级别。</string>
     <string name="troubleshoot_debug_bundle">上传调试包</string>
     <string name="troubleshoot_anonymize">匿名化敏感数据</string>
+    <string name="troubleshoot_anonymize_desc">隐藏 IP 地址、域名和其他敏感值。</string>
+    <string name="troubleshoot_anonymize_none">无</string>
+    <string name="troubleshoot_anonymize_none_description">所有内容均保持可读。请仅在组织内部分享。</string>
+    <string name="troubleshoot_anonymize_default">默认</string>
+    <string name="troubleshoot_anonymize_default_description">隐藏公网 IP 地址和域名。内部 IPv4 地址和对等节点名称保持可读，便于支持人员查看。</string>
+    <string name="troubleshoot_anonymize_strict">严格</string>
+    <string name="troubleshoot_anonymize_strict_description">同时隐藏私有、CGNAT 和链路本地地址、对等节点名称以及 WireGuard 密钥。向组织外分享时请使用。</string>
     <string name="troubleshoot_section_logging">日志</string>
     <string name="troubleshoot_section_debug_bundle">调试包</string>
     <string name="advanced_rosenpass">启用 Rosenpass</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -188,6 +188,13 @@
     <string name="advanced_tracelog">Enable trace log level.</string>
     <string name="troubleshoot_debug_bundle">Upload debug bundle</string>
     <string name="troubleshoot_anonymize">Anonymize sensitive data</string>
+    <string name="troubleshoot_anonymize_desc">Hides IP addresses, domains, and other sensitive values.</string>
+    <string name="troubleshoot_anonymize_none">None</string>
+    <string name="troubleshoot_anonymize_none_description">Everything stays readable. Only share inside your organization.</string>
+    <string name="troubleshoot_anonymize_default">Default</string>
+    <string name="troubleshoot_anonymize_default_description">Hides public IP addresses and domains. Internal IPv4 addresses and peer names stay readable for support.</string>
+    <string name="troubleshoot_anonymize_strict">Strict</string>
+    <string name="troubleshoot_anonymize_strict_description">Also hides private, CGNAT and link-local addresses, peer names and WireGuard keys. Use it outside your organization.</string>
     <string name="troubleshoot_section_logging">Logging</string>
     <string name="troubleshoot_section_debug_bundle">Debug bundle</string>
     <string name="advanced_rosenpass">Enable Rosenpass</string>

--- a/tool/src/main/java/io/netbird/client/tool/EngineRunner.java
+++ b/tool/src/main/java/io/netbird/client/tool/EngineRunner.java
@@ -436,15 +436,13 @@ class EngineRunner {
         }
     }
 
-    public String debugBundle(boolean anonymize) throws Exception {
+    public String debugBundle(boolean anonymize, String anonymizeLevel) throws Exception {
         String configPath = profileManager.getActiveConfigPath();
         String statePath = profileManager.getActiveStateFilePath();
         String cacheDir = context.getCacheDir().getAbsolutePath();
         var platformFiles = new AndroidPlatformFiles(configPath, statePath, cacheDir);
         try {
-            // The strict level stays unused until the troubleshoot screen
-            // grows an option for it.
-            return goClient.debugBundle(platformFiles, anonymize, Android.AnonymizeLevelDefault);
+            return goClient.debugBundle(platformFiles, anonymize, anonymizeLevel);
         } catch (Exception e) {
             Log.e(LOGTAG, "goClient error", e);
             throw e;

--- a/tool/src/main/java/io/netbird/client/tool/Preferences.java
+++ b/tool/src/main/java/io/netbird/client/tool/Preferences.java
@@ -5,9 +5,17 @@ import android.content.SharedPreferences;
 
 public class Preferences {
 
+    public static final String ANONYMIZE_LEVEL_NONE = "none";
+
+    public static final String ANONYMIZE_LEVEL_DEFAULT = "default";
+
+    public static final String ANONYMIZE_LEVEL_STRICT = "strict";
+
     private final String keyTraceLog = "tracelog";
 
     private final String keyForceRelayConnection = "isConnectionForceRelayed";
+
+    private final String keyAnonymizeLevel = "anonymizeLevel";
 
     private final SharedPreferences sharedPref;
 
@@ -24,6 +32,14 @@ public class Preferences {
 
     public void disableTraceLog() {
         sharedPref.edit().putBoolean(keyTraceLog, false).apply();
+    }
+
+    public String getAnonymizeLevel() {
+        return sharedPref.getString(keyAnonymizeLevel, ANONYMIZE_LEVEL_DEFAULT);
+    }
+
+    public void setAnonymizeLevel(String level) {
+        sharedPref.edit().putString(keyAnonymizeLevel, level).apply();
     }
 
     public boolean isConnectionForceRelayed() {

--- a/tool/src/main/java/io/netbird/client/tool/VPNService.java
+++ b/tool/src/main/java/io/netbird/client/tool/VPNService.java
@@ -330,8 +330,8 @@ public class VPNService extends android.net.VpnService {
             }
         }
 
-        public String debugBundle(boolean anonymize) throws Exception {
-            return engineRunner.debugBundle(anonymize);
+        public String debugBundle(boolean anonymize, String anonymizeLevel) throws Exception {
+            return engineRunner.debugBundle(anonymize, anonymizeLevel);
         }
 
         /**


### PR DESCRIPTION
The troubleshoot screen exposed anonymization as a plain on/off switch that kept no state: it reset to off on every fragment recreation, so a bundle went up unanonymized unless the user toggled it again right before uploading. The strict level the Go binding already exports was unreachable, because EngineRunner passed AnonymizeLevelDefault unconditionally.

Replace the switch with a None / Default / Strict picker that mirrors the desktop client. The selection persists in the app-wide SharedPreferences and defaults to Default. The row moves from the Logging section into the Debug bundle section, since it only affects the bundle.

The picker is a bottom sheet built on the existing SplitTunnelModeSheet pattern, so each level carries a description explaining what it hides. The level-to-parameter mapping follows the desktop client: "none" turns the anonymize flag off, and the daemon only ever sees "default" or "strict".

Level names and descriptions are taken from the already translated desktop strings for all ten locales.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added selectable debug-bundle anonymization levels: None, Default, and Strict.
  * The Troubleshoot screen now displays the selected anonymization level and saves it for future use.
  * Debug bundles use the selected anonymization level when generated.
  * Added localized descriptions and labels for anonymization options in multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->